### PR TITLE
docs: add reproducible Oura dogfooding runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ ephemeral and repo-local (no `brew services`, no autostart).
 ```bash
 make mac-setup            # brew postgresql@16 + redis if missing, initdb,
                           # create DBs, uv sync
-cp .env.example .env      # optional: sqlite works with zero config
+install -m 600 .env.example .env  # optional: sqlite works with zero config
 make mac-run              # alembic upgrade head + service on :8100
 curl http://localhost:8100/health
 make mac-test             # full offline test suite
@@ -201,8 +201,8 @@ With no `.env` at all, the service runs against a repo-local sqlite file —
 ### Docker alternative
 
 ```bash
-cp .env.example .env
-cp config/open-wearables.env.example config/open-wearables.env
+install -m 600 .env.example .env
+install -m 600 config/open-wearables.env.example config/open-wearables.env
 docker compose up -d --build     # postgres, redis, open-wearables (+worker,
                                  # +mcp), healthmes, hermes gateway
 ```

--- a/config/open-wearables.env.example
+++ b/config/open-wearables.env.example
@@ -1,7 +1,7 @@
 # Environment for the open-wearables backend/worker (repo-root copy so
 # vendor/ stays untouched).
 #
-#   cp config/open-wearables.env.example config/open-wearables.env
+#   install -m 600 config/open-wearables.env.example config/open-wearables.env
 #
 # Consumed by BOTH run paths:
 #   - mac-native: scripts/dev_mac.sh `ow` / `ow-worker` source-exports this
@@ -70,6 +70,18 @@ SVIX_SERVER_URL=http://localhost:8071
 #--- Providers ---#
 # Public base URL of the API (used for OAuth redirect URIs, etc.)
 API_BASE_URL=http://localhost:8000
+
+# Oura Cloud OAuth app (https://cloud.ouraring.com/oauth/applications)
+# Register this redirect URI exactly:
+#   http://localhost:8000/api/v1/oauth/oura/callback
+# Keep the real secret only in config/open-wearables.env (gitignored).
+OURA_CLIENT_ID=your-oura-client-id
+OURA_CLIENT_SECRET=your-oura-client-secret
+# `daily` covers daily sleep, activity, and readiness summaries. The app used
+# for the 2026-07-12 dogfood did not expose the vendored backend's separate
+# legacy `activity` scope.
+OURA_DEFAULT_SCOPE="personal daily heartrate workout session spo2 ring_configuration heart_health"
+
 # Add provider credentials from vendor/open-wearables/backend/config/.env.example
 # as needed (SUUNTO_*, POLAR_*, GARMIN_*, WHOOP_*, OURA_*, STRAVA_*, FITBIT_*,
 # ULTRAHUMAN_*).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -26,7 +26,7 @@ a full one-command stack.
 make mac-setup            # brew install postgresql@16 + redis (if missing),
                           # initdb ./data/pg, start pg+redis, create the
                           # open-wearables + healthmes databases, uv sync
-cp .env.example .env      # optional: tweak HEALTHMES_* values
+install -m 600 .env.example .env  # optional: tweak HEALTHMES_* values
 make mac-run              # alembic upgrade head + uvicorn :8100
 curl http://localhost:8100/health   # -> {"status":"ok"}
 make mac-test             # uv run pytest -q
@@ -82,6 +82,91 @@ Notes:
   worker the OW API still serves, but no background syncs happen.
 - postgresql@16 is keg-only; the scripts call binaries via
   `$(brew --prefix postgresql@16)/bin` — no PATH changes needed.
+
+### Oura OAuth dogfooding (mac-native)
+
+Create an OAuth application in the
+[Oura Cloud developer portal](https://cloud.ouraring.com/oauth/applications).
+The registered redirect URI must match this value exactly:
+
+```text
+http://localhost:8000/api/v1/oauth/oura/callback
+```
+
+Copy the root example and put the Oura credentials only in the ignored local
+file:
+
+```bash
+install -m 600 config/open-wearables.env.example config/open-wearables.env
+```
+
+```dotenv
+OURA_CLIENT_ID=replace-with-client-id
+OURA_CLIENT_SECRET=replace-with-client-secret
+OURA_DEFAULT_SCOPE="personal daily heartrate workout session spo2 ring_configuration heart_health"
+API_BASE_URL=http://localhost:8000
+HISTORICAL_SYNC_ON_CONNECT=false
+```
+
+`daily` includes Oura's daily sleep, activity, and readiness summaries. Do not
+add the legacy separate `activity` scope when the Oura application UI does not
+offer it. Never paste the client secret into Git, screenshots, issue comments,
+or chat logs. Setting `HISTORICAL_SYNC_ON_CONNECT=false` disables the vendored
+grace-period backfill so the explicit historical task below is the single sync
+run being verified.
+
+Start the data plane in separate terminals so the API and its background sync
+worker are both present:
+
+```bash
+make mac-services-start
+make mac-ow
+```
+
+```bash
+make mac-ow-worker
+```
+
+Open <http://localhost:8000/docs> and use the OpenAPI operations in this order:
+
+1. Click **Authorize** and enter the developer email and password from the local
+   `ADMIN_EMAIL` and `ADMIN_PASSWORD` settings. The OpenAPI UI calls
+   `POST /api/v1/auth/login` for the bearer token; do not copy the token into
+   notes or logs.
+2. Select or create the local test user with `GET /api/v1/users` or
+   `POST /api/v1/users`.
+3. Call `GET /api/v1/oauth/{provider}/authorize` with `provider=oura` and the
+   selected `user_id`, then open the returned `authorization_url`. Complete
+   consent in Oura; Oura redirects to the registered concrete callback URI and
+   the callback should report a successful connection.
+4. Confirm `GET /api/v1/users/{user_id}/connections` contains an `oura`
+   connection with `status: active`.
+5. Queue `POST /api/v1/providers/{provider}/users/{user_id}/sync/historical`
+   with `provider=oura` and `days=90`. A successful request returns
+   `success: true` and a task ID.
+6. Confirm the corresponding Oura run reaches `status: success` in
+   `GET /api/v1/users/{user_id}/sync/runs`. This proves the Celery worker
+   completed the historical task, not merely that the API accepted it.
+7. Query `GET /api/v1/users/{user_id}/summaries/sleep` and
+   `GET /api/v1/users/{user_id}/health-scores?provider=oura&category=readiness`
+   with a date range that covers days present in the Oura account. At least one
+   non-empty response proves the personal-date sleep/readiness data path.
+
+Record only sanitized evidence:
+
+```text
+repo commit: <commit>
+Oura connection: active | blocked
+sync: success | failed
+sleep/readiness data: returned | empty
+first blocker: <first failure or none>
+screenshot/log: <redacted path or summary>
+```
+
+Do not record credentials, bearer/refresh tokens, authorization codes, email
+addresses, user IDs, task IDs, or raw health payloads. A `200` from `/docs`
+proves only that the API is serving; it does not prove provider sync unless the
+Celery task also completes.
 
 ## Run the healthmes service directly
 
@@ -411,8 +496,8 @@ real credentials.
 ## Full stack (docker compose, alternative path)
 
 ```bash
-cp .env.example .env                                       # tokens/keys
-cp config/open-wearables.env.example config/open-wearables.env
+install -m 600 .env.example .env                           # tokens/keys
+install -m 600 config/open-wearables.env.example config/open-wearables.env
 docker compose config -q      # validate
 docker compose up -d --build
 ```


### PR DESCRIPTION
## Summary

- document the exact Oura OAuth callback and the scope set validated during mac-native dogfooding
- use one deterministic historical-sync flow and verify the Celery run plus Oura readiness data
- create root and Open Wearables credential files with owner-only permissions

## Validation

- parsed the example environment and matched every documented route against the live OpenAPI schema
- observed an active Oura connection, a completed successful historical backfill, and a non-empty readiness response
- passed goal/quality/context/security/QA review after fixing Swagger auth, sync-task ambiguity, readiness filtering, commit metadata, and env-file permissions

## Security

- no credentials, tokens, authorization codes, user/task identifiers, personal emails, raw health payloads, or local evidence logs are included
- real environment files and the data directory remain ignored