### PR TITLE
chore: dependabot config for this repo's own surfaces (replaces stale #1-#5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependency updates for THIS repo's own surfaces only.
+# vendor/ is never touched by automation — upstream sync is manual
+# (scripts/vendor_sync_check.sh); dependabot must not reach into it.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: gradle
+    directory: /apps/android-usage
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: nuget
+    directory: /apps/windows-companion
+    schedule:
+      interval: weekly


### PR DESCRIPTION
All five pre-reorganization dependabot PRs were permanently CONFLICTING (they edited root workflow files that moved under vendor/ in ca5ab19) — closed with rationale. This adds a proper config scoped to what we actually own: the four CI workflows, the uv Python tree, the Android Gradle project, and the Windows solution. vendor/ deliberately excluded (manual upstream sync policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)