### PR TITLE
fix(viewer): never truncate decision-tree node labels

### DIFF
--- a/healthmes/api/decision_html.py
+++ b/healthmes/api/decision_html.py
@@ -210,6 +210,59 @@ _MERMAID_LABEL_TRANSLATION = str.maketrans(
 )
 
 
+def _char_units(ch: str) -> float:
+    """Rough display width of one char (Korean/CJK = full-width = 1.0)."""
+    if ch.isspace():
+        return 0.34
+    return 1.0 if ord(ch) > 0x2E7F else 0.56
+
+
+def _wrap_units(text: str, max_units: float, max_lines: int) -> list[str]:
+    """Greedy width-estimated word wrap (long words hard-break by char).
+
+    Used for the Mermaid diagram labels (joined with ``<br/>`` AFTER each
+    line went through :func:`escape_mermaid_label`) so long 판단 questions
+    stay fully readable instead of being cut. Beyond ``max_lines`` the last
+    line is clamped with an ellipsis — the full text always remains in the
+    node detail panel and the list rail.
+    """
+    lines: list[str] = []
+    current = ""
+    current_units = 0.0
+
+    def units(chunk: str) -> float:
+        return sum(_char_units(ch) for ch in chunk)
+
+    def commit() -> None:
+        nonlocal current, current_units
+        if current:
+            lines.append(current)
+        current = ""
+        current_units = 0.0
+
+    for word in text.split():
+        word_units = units(word)
+        if current and current_units + 0.34 + word_units > max_units:
+            commit()
+        if word_units > max_units:
+            for ch in word:
+                w = _char_units(ch)
+                if current and current_units + w > max_units:
+                    commit()
+                current += ch
+                current_units += w
+            continue
+        current = f"{current} {word}" if current else word
+        current_units += (0.34 if current_units else 0.0) + word_units
+    commit()
+    if not lines:
+        return [text.strip() or text]
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines[-1] = lines[-1].rstrip() + "…"
+    return lines
+
+
 def escape_mermaid_label(text: str) -> str:
     """Escape user-derived text for use inside a quoted Mermaid label.
 
@@ -410,7 +463,12 @@ def tree_to_mermaid(tree: Any) -> DecisionTreeView:
             diagram_label = node.label
             if len(diagram_label) > MAX_DIAGRAM_LABEL_CHARS:
                 diagram_label = diagram_label[: MAX_DIAGRAM_LABEL_CHARS - 1] + "…"
-            escaped = escape_mermaid_label(diagram_label)
+            # Full-width-aware wrapping; each line is sanitised separately and
+            # only OUR <br/> separators exist in the label (user <> is inert).
+            escaped = "<br/>".join(
+                escape_mermaid_label(line)
+                for line in _wrap_units(diagram_label, max_units=15.0, max_lines=4)
+            )
             lines.append(f"  {node.gid}{open_mark}{escaped}{close_mark}:::type_{node.type}")
             if parent is not None:
                 lines.append(f"  {parent.gid} --> {node.gid}")

--- a/healthmes/api/templates/ui/decision.html.j2
+++ b/healthmes/api/templates/ui/decision.html.j2
@@ -94,7 +94,7 @@
   .fnode-option .ntype   { fill: #146055; }
   .fnode-action .ntype   { fill: #2b6532; }
   .fnode-other .ntype    { fill: #4e5b55; }
-  .nlabel { fill: #22312a; font-size: 11.5px; font-weight: 600; text-anchor: middle; }
+  .nlabel { fill: #22312a; font-size: 12px; font-weight: 600; text-anchor: middle; }
   g.fnode.chosen .ncard {
     stroke: var(--brand); stroke-width: 2.4;
     filter: drop-shadow(0 1px 4px rgba(18, 128, 108, 0.35));
@@ -556,8 +556,11 @@
   });
   var collapsed = {};
   var gEls = {};
-  var PILL_W = 170, PILL_H = 46;
-  var DX = 192, DY = 112, TOP_PAD = 30, BOTTOM_PAD = 46, SIDE_PAD = 112;
+  var measures = {};
+  var CARD_W = 240, PAD_X = 12, INNER_W = CARD_W - PAD_X * 2;
+  var LINE_H = 16, MAX_LINES = 4;
+  var DX = CARD_W + 24, GAP_Y = 54, TOP_PAD = 26, BOTTOM_PAD = 44;
+  var SIDE_PAD = CARD_W / 2 + 24;
 
   function countSubtree(gid) {
     var n = 1;
@@ -594,15 +597,107 @@
       return node;
     }
     roots.forEach(function (gid) { walk(gid, 0, false); });
-    var H = TOP_PAD + BOTTOM_PAD + maxDepth * DY + PILL_H;
+    /* rows are as tall as their tallest card; centers per row keep the
+       tidy shape while every label stays fully visible */
+    var rowH = [];
+    nodes.forEach(function (n) {
+      n.h = measure(n.gid).h;
+      if (!rowH[n.depth] || n.h > rowH[n.depth]) { rowH[n.depth] = n.h; }
+    });
+    var rowY = [], y = TOP_PAD;
+    for (var d = 0; d <= maxDepth; d++) {
+      var h = rowH[d] || 50;
+      rowY[d] = y + h / 2;
+      y += h + GAP_Y;
+    }
+    var H = y - GAP_Y + BOTTOM_PAD;
     var W = Math.max(SIDE_PAD * 2 + Math.max(leafCount - 1, 0) * DX, 360);
-    nodes.forEach(function (n) { n.y = TOP_PAD + PILL_H / 2 + n.depth * DY; });
+    nodes.forEach(function (n) { n.y = rowY[n.depth]; });
     return { nodes: nodes, links: links, W: W, H: H };
   }
 
   function truncate(text, max) {
     text = String(text);
     return text.length > max ? text.slice(0, max - 1) + "…" : text;
+  }
+
+  /* ---- full-label wrapping (no ellipsis up to MAX_LINES) ----
+     Width is estimated per char: Korean/CJK counts as full-width. The full
+     text additionally lives in <title> and the detail panel. */
+  function charW(ch, size) {
+    if (ch === " ") { return size * 0.34; }
+    return ch.charCodeAt(0) > 0x2e7f ? size : size * 0.56;
+  }
+  function textW(text, size) {
+    var w = 0;
+    for (var i = 0; i < text.length; i++) { w += charW(text.charAt(i), size); }
+    return w;
+  }
+  function wrapText(text, size, maxW, maxLines) {
+    var words = String(text).split(/\s+/).filter(function (w) { return w.length; });
+    var lines = [], current = "";
+    function commit() { if (current) { lines.push(current); current = ""; } }
+    words.forEach(function (word) {
+      if (textW(word, size) > maxW) {
+        for (var i = 0; i < word.length; i++) {
+          var ch = word.charAt(i);
+          if (current && textW(current + ch, size) > maxW) { commit(); }
+          current += ch;
+        }
+        return;
+      }
+      var candidate = current ? current + " " + word : word;
+      if (current && textW(candidate, size) > maxW) { commit(); current = word; }
+      else { current = candidate; }
+    });
+    commit();
+    if (!lines.length) { lines = [String(text)]; }
+    var clamped = false;
+    if (lines.length > maxLines) {
+      lines = lines.slice(0, maxLines);
+      var last = lines[maxLines - 1];
+      while (last.length && textW(last + "…", size) > maxW) { last = last.slice(0, -1); }
+      lines[maxLines - 1] = last + "…";
+      clamped = true;
+    }
+    return { lines: lines, clamped: clamped };
+  }
+  /* "<kicker> — <body>" labels: the kicker becomes a small overline and the
+     body (the actual question) is the dominant wrapped text. */
+  function splitLabel(text) {
+    text = String(text);
+    var seps = [" — ", " – ", " - ", "—", "–"];
+    for (var i = 0; i < seps.length; i++) {
+      var idx = text.indexOf(seps[i]);
+      if (idx > 0 && idx <= 20) {
+        var kicker = text.slice(0, idx).trim();
+        var body = text.slice(idx + seps[i].length).trim();
+        if (kicker && body) { return { kicker: kicker, body: body }; }
+      }
+    }
+    return { kicker: "", body: text.trim() };
+  }
+  function measure(gid) {
+    if (measures[gid]) { return measures[gid]; }
+    var info = nodeData[gid];
+    var parts = splitLabel(info.label);
+    var overline = info.type === "other" && info.raw_type
+      ? truncate(info.raw_type, 18)
+      : (typeLabels[info.type] || info.type);
+    if (parts.kicker) { overline += " · " + parts.kicker; }
+    if (info.chosen) { overline += " · 채택"; }
+    else if (info.rejected) { overline += " · 기각"; }
+    while (overline.length > 2 && textW(overline, 9) > INNER_W) {
+      overline = overline.slice(0, -2) + "…";
+    }
+    var wrapped = wrapText(parts.body, 12, INNER_W, MAX_LINES);
+    measures[gid] = {
+      overline: overline,
+      lines: wrapped.lines,
+      clamped: wrapped.clamped,
+      h: 50 + (wrapped.lines.length - 1) * LINE_H
+    };
+    return measures[gid];
   }
 
   function onNodeActivate(gid, g) {
@@ -617,30 +712,37 @@
   function ensureNodeEl(node) {
     var g = gEls[node.gid];
     if (!g) {
+      var m = measure(node.gid);
       g = document.createElementNS(SVGNS, "g");
       g.setAttribute("data-gid", node.gid);
       g.setAttribute("tabindex", "0");
       g.setAttribute("role", "button");
       var card = document.createElementNS(SVGNS, "rect");
       card.setAttribute("class", "ncard");
-      card.setAttribute("x", -PILL_W / 2);
-      card.setAttribute("y", -PILL_H / 2);
-      card.setAttribute("width", PILL_W);
-      card.setAttribute("height", PILL_H);
+      card.setAttribute("x", -CARD_W / 2);
+      card.setAttribute("y", -m.h / 2);
+      card.setAttribute("width", CARD_W);
+      card.setAttribute("height", m.h);
       card.setAttribute("rx", 10);
       g.appendChild(card);
       var typeText = document.createElementNS(SVGNS, "text");
       typeText.setAttribute("class", "ntype");
-      typeText.setAttribute("y", -5);
+      typeText.setAttribute("y", -m.h / 2 + 18);
+      typeText.textContent = m.overline;
       g.appendChild(typeText);
       var label = document.createElementNS(SVGNS, "text");
       label.setAttribute("class", "nlabel");
-      label.setAttribute("y", 13);
-      label.textContent = truncate(node.info.label, 15);
+      m.lines.forEach(function (line, i) {
+        var span = document.createElementNS(SVGNS, "tspan");
+        span.setAttribute("x", 0);
+        span.setAttribute("y", -m.h / 2 + 36 + i * LINE_H);
+        span.textContent = line;
+        label.appendChild(span);
+      });
       g.appendChild(label);
       var bud = document.createElementNS(SVGNS, "text");
       bud.setAttribute("class", "bud");
-      bud.setAttribute("y", PILL_H / 2 + 15);
+      bud.setAttribute("y", m.h / 2 + 15);
       g.appendChild(bud);
       var tip = document.createElementNS(SVGNS, "title");
       tip.textContent = node.info.label;
@@ -658,8 +760,8 @@
   }
 
   function edgePath(link) {
-    var px = link.parent.x, py = link.parent.y + PILL_H / 2;
-    var cx = link.child.x, cy = link.child.y - PILL_H / 2;
+    var px = link.parent.x, py = link.parent.y + link.parent.h / 2;
+    var cx = link.child.x, cy = link.child.y - link.child.h / 2;
     var gap = (cy - py) * 0.5;
     return "M" + px + "," + py +
       " C" + px + "," + (py + gap) +
@@ -701,13 +803,6 @@
       if (node.gid === selectedGid) { cls += " selected"; }
       g.setAttribute("class", cls);
       g.style.transform = "translate(" + node.x + "px, " + node.y + "px)";
-      var typeText = g.querySelector(".ntype");
-      var typeName = info.type === "other" && info.raw_type
-        ? truncate(info.raw_type, 18)
-        : (typeLabels[info.type] || info.type);
-      if (info.chosen) { typeName += " · 채택"; }
-      else if (info.rejected) { typeName += " · 기각"; }
-      typeText.textContent = typeName;
       var bud = g.querySelector(".bud");
       bud.textContent = node.hidden > 0 ? "+" + node.hidden : "";
       var state = [info.label, typeLabels[info.type] || info.type];

--- a/tests/api/test_decisions_viewer.py
+++ b/tests/api/test_decisions_viewer.py
@@ -511,6 +511,49 @@ def test_decision_page_three_zones(client, session):
     assert "proposed schedule change" not in pre
 
 
+def test_long_labels_render_without_truncation(client, session):
+    """Long 판단 questions must stay fully readable (round-6: 생략 금지).
+
+    The island keeps the untruncated label (the client tree wraps it across
+    tspan lines instead of cutting it) and the Mermaid label is broken into
+    our own <br/> segments — sanitiser intact, full text preserved.
+    """
+    long_label = (
+        "판단 1 — 오후 일정 밀도와 수면 부채를 함께 고려했을 때 "
+        "지금 집중 블록을 유지하는 것이 회복에 유리한가에 대한 검토"
+    )  # 60+ chars
+    assert len(long_label) > 60
+    record = _seed_decision(
+        session,
+        tree={
+            "id": "r",
+            "type": "rule",
+            "label": long_label,
+            "children": [
+                {"id": "o", "type": "option", "label": "짧은 옵션", "children": []}
+            ],
+        },
+    )
+
+    html = client.get(f"/decisions/{record.id}").text
+
+    # Island: the full label, no ellipsis anywhere near it.
+    island = _ISLAND_RE.search(html)
+    assert island
+    data = json.loads(island.group(1))
+    assert data["n0"]["label"] == long_label
+    assert "…" not in data["n0"]["label"]
+    # Mermaid: our <br/> separators (autoescaped in the pre) split the label,
+    # and rejoining them restores every fragment including the tail.
+    pre = html.split('<pre id="decision-graph"', 1)[1].split("</pre>", 1)[0]
+    assert "&lt;br/&gt;" in pre
+    rejoined = pre.replace("&lt;br/&gt;", " ")
+    assert "유리한가에 대한 검토" in rejoined  # the tail survived, not cut
+    assert "판단 1" in rejoined
+    # No user-controlled markup was introduced by the line breaking.
+    assert "<br/>" not in pre  # only the escaped form exists inside the pre
+
+
 def test_decision_page_without_process_tree(client, session):
     """Input-only records: graceful 결정 분기 없음 + grouped list fallback."""
     record = _seed_decision(


### PR DESCRIPTION
Node pills clipped labels to one line — cascades showed only the "판단 1 —" prefix with the actual question hidden. Adds tspan line-wrapping (CJK-aware width model, ≤4 lines/240px card, ellipsis only beyond with full text in title+panel), kicker—body split (question becomes the dominant text), variable-height tidy layout, server-side mermaid label wrapping with per-line escaping, and an unclamped-long-Korean-label test. 921 pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)