### PR TITLE
feat(alerts): native-app delivery without Telegram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,13 @@ HEALTHMES_API_TOKEN=
 # cognitive-energy persist, weekly backup).
 HEALTHMES_SCHEDULER_ENABLED=false
 
+# Deliver proactive alerts to the native companion apps (iOS/Android), which
+# poll /v1/alerts + /v1/briefing/glance — the phone (and mirrored watch) get
+# alerts WITHOUT Telegram. Turn this on for a Telegram-free setup; leave off
+# if the Hermes webhook is your only delivery channel. Alert hygiene (quiet
+# hours / cooldown / daily budget / dedup) applies either way.
+#HEALTHMES_NATIVE_ALERT_DELIVERY=true
+
 # IANA timezone of the user (e.g. Asia/Seoul) — local-day boundaries and the
 # calendar/app-usage joins in the MCP tools use it. Leave unset on mac-native
 # (machine timezone wins); set it when running in docker, where container

--- a/healthmes/config.py
+++ b/healthmes/config.py
@@ -105,6 +105,19 @@ class Settings(BaseSettings):
         "docker containers run UTC clocks, so compose forwards HEALTHMES_TIMEZONE).",
     )
 
+    # Delivery: proactive alerts reach the user through the Hermes webhook
+    # (phone+watch via Telegram) AND/OR the native companion apps, which poll
+    # /v1/alerts + /v1/briefing/glance. With native delivery on, a fired
+    # trigger is surfaced to the apps even when no Hermes webhook is
+    # configured or its push fails — so the phone gets alerts without Telegram.
+    native_alert_delivery: bool = Field(
+        default=False,
+        description="Surface fired triggers to the native companion apps "
+        "(/v1/alerts + glance) regardless of the Hermes webhook outcome — "
+        "enables phone/watch alerts without Telegram. Alert hygiene (quiet "
+        "hours, cooldown, daily budget, dedup) still applies.",
+    )
+
     # Native capture uploads (issue #10 companion apps; healthmes/api/media.py).
     media_max_upload_bytes: int = Field(
         default=15 * 1024 * 1024,

--- a/healthmes/engine/triggers.py
+++ b/healthmes/engine/triggers.py
@@ -16,9 +16,13 @@ Runs every ``TRIGGER_INTERVAL_MINUTES`` from the in-service APScheduler
 4. gate the push with the alert-hygiene settings (quiet hours, per-rule
    cooldown, daily alert budget — docs/PLAN.md section 11) and, if allowed,
    POST it to the Hermes gateway via ``healthmes/engine/webhook.py``.
-   ``alert_sent`` is True only after a confirmed 2xx push; suppressed and
-   failed pushes keep the row with the reason in ``payload["push"]`` and are
-   NOT retried for the same dedup key (noise control beats redelivery).
+   ``alert_sent`` marks the alert as delivered to the user: True after a
+   confirmed 2xx webhook push, OR — when ``native_alert_delivery`` is on —
+   whenever a fire passes the hygiene gates, so the native companion apps
+   surface it via /v1/alerts + glance even without Telegram. Suppressed and
+   webhook-only-failed pushes keep the row with the reason in
+   ``payload["push"]`` and are NOT retried for the same dedup key (noise
+   control beats redelivery).
 
 Datetime convention: everything is normalized to UTC before it is persisted
 or bound into a query, so comparisons behave identically on postgres
@@ -674,7 +678,27 @@ class TriggerEvaluator:
         result = self._alert_sender.send(fire, fired_at=now)
         if result.ok:
             event.alert_sent = True
-            event.payload = {**payload, "push": {"sent": True, "status_code": result.status_code}}
+            event.payload = {
+                **payload,
+                "push": {"sent": True, "status_code": result.status_code, "channel": "webhook"},
+            }
+            return FireOutcome(fire=fire, status="pushed")
+
+        # Webhook not delivered (unconfigured or failed). With native delivery
+        # on, the alert is still surfaced to the companion apps via /v1/alerts +
+        # glance polling — the phone/watch get it without Telegram.
+        if self._settings.native_alert_delivery:
+            event.alert_sent = True
+            event.payload = {
+                **payload,
+                "push": {
+                    "sent": True,
+                    "channel": "native",
+                    "webhook_ok": False,
+                    "status_code": result.status_code,
+                    "detail": result.detail,
+                },
+            }
             return FireOutcome(fire=fire, status="pushed")
 
         event.payload = {

--- a/tests/engine/test_triggers.py
+++ b/tests/engine/test_triggers.py
@@ -221,7 +221,7 @@ def test_fresh_fire_is_persisted_and_pushed(settings, session_factory, alert_sen
     assert event.alert_sent is True
     assert event.payload["summary"] == fire.summary
     assert event.payload["evidence"]["recent_value"] == 85.0
-    assert event.payload["push"] == {"sent": True, "status_code": 202}
+    assert event.payload["push"] == {"sent": True, "status_code": 202, "channel": "webhook"}
 
 
 def test_dedup_key_is_unique_across_sweeps(settings, session_factory, alert_sender) -> None:
@@ -254,6 +254,38 @@ def test_failed_push_is_recorded_and_not_retried(settings, session_factory) -> N
     assert event.alert_sent is False
     assert event.payload["push"]["suppressed_reason"] == "push_failed"
     assert event.payload["push"]["status_code"] == 502
+
+
+def test_native_delivery_surfaces_alert_without_webhook(settings, session_factory) -> None:
+    """native_alert_delivery on: a fired trigger is marked delivered even when
+    the webhook is absent/fails, so the companion apps surface it via
+    /v1/alerts + glance (phone alerts without Telegram — user request). Alert
+    hygiene still gates it."""
+    native_settings = settings.model_copy(update={"native_alert_delivery": True})
+    sender = FakeAlertSender(ok=False)  # no Hermes webhook configured / unreachable
+    with freeze_time("2026-07-09 14:00:00"):
+        evaluator = make_evaluator(native_settings, session_factory, sender, rules=(fixed_rule,))
+        report = evaluator.evaluate_once()
+
+    assert [o.status for o in report.outcomes] == ["pushed"]
+    [event] = all_events(session_factory)
+    # Surfaced for native polling (glance/alerts filter on alert_sent) despite
+    # the webhook failure — the phone gets it without Telegram.
+    assert event.alert_sent is True
+    assert event.payload["push"]["channel"] == "native"
+    assert event.payload["push"]["webhook_ok"] is False
+
+
+def test_native_delivery_off_keeps_webhook_only_semantics(settings, session_factory) -> None:
+    """Default (native off): a failed webhook leaves the alert undelivered."""
+    sender = FakeAlertSender(ok=False)
+    with freeze_time("2026-07-09 14:00:00"):
+        evaluator = make_evaluator(settings, session_factory, sender, rules=(fixed_rule,))
+        report = evaluator.evaluate_once()
+
+    assert [o.status for o in report.outcomes] == ["push_failed"]
+    [event] = all_events(session_factory)
+    assert event.alert_sent is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the coupling that made proactive alerts require the Hermes/Telegram webhook: alerts only surfaced to the native apps (`/v1/alerts` + glance) after a 2xx webhook push, so a Telegram-free setup notified nothing.

New `HEALTHMES_NATIVE_ALERT_DELIVERY`: when on, a fired trigger passing the hygiene gates is marked delivered regardless of the webhook outcome, so the iOS/Android companion apps surface it via their existing poll — **phone (and mirrored watch) alerts without Telegram**. Quiet hours / cooldown / daily budget / dedup still apply; the payload records the channel (webhook | native). Two new trigger tests. 923 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)