### PR TITLE
fix: independent GPT-5.6 review findings — timezone, data-honesty, ownership, alert-loss, security

### DIFF
--- a/healthmes/api/templates/ui/index.html.j2
+++ b/healthmes/api/templates/ui/index.html.j2
@@ -1,9 +1,10 @@
 {% extends "ui/_base.html.j2" %}
-{# Landing shell for GET / — static links only, no store data, no credentials
-   in the markup (safe under any auth posture). The tiny inline script only
-   copies a ?token= already present in the *visitor's own URL* onto the
-   same-origin links, so tokened demo links keep working; nothing secret is
-   ever rendered server-side here. #}
+{# Landing shell for GET / — static links only, no store data, and NO
+   credentials anywhere: not in the markup, and not propagated onto the links.
+   The viewer token is an HMAC of the API token that the client cannot derive,
+   so the landing carries no credentials — every link is a bare same-origin
+   path, safe to serve to anyone the auth middleware lets through and under any
+   future auth posture. #}
 
 {% block title %}HealthMes — 몸의 신호로 하루를 조율하는 로컬 에이전트{% endblock %}
 
@@ -59,17 +60,17 @@
     <span class="loop-arrow" aria-hidden="true">→</span> 궁금할 땐 "왜?"를 눌러 근거 숲을 봅니다.</p>
 
   <nav class="surface-grid" aria-label="서비스 표면">
-    <a class="surface-card" data-token-link href="/decisions">
+    <a class="surface-card" href="/decisions">
       <h2>제안 · 피드백 기록</h2>
       <p>일정 조정 제안과 하루 피드백, 근거 숲과 함께 최신순.</p>
       <code>GET /decisions</code>
     </a>
-    <a class="surface-card" data-token-link href="/reports/weekly">
+    <a class="surface-card" href="/reports/weekly">
       <h2>주간 리포트</h2>
       <p>에너지 추이 · 인사이트 · 일정 수용률 · 알림 예산.</p>
       <code>GET /reports/weekly</code>
     </a>
-    <a class="surface-card" data-token-link href="/v1/briefing/glance">
+    <a class="surface-card" href="/v1/briefing/glance">
       <h2>글랜스 브리핑</h2>
       <p>컴패니언 앱이 읽는 지금-상태 스냅샷 (JSON).</p>
       <code>GET /v1/briefing/glance</code>
@@ -84,21 +85,4 @@
   <p class="local-note"><span class="brand-dot" aria-hidden="true"></span>
     모든 건강 데이터는 이 기기에만 머뭅니다 · Local-first, no cloud.</p>
 </div>
-{% endblock %}
-
-{% block scripts %}
-<script>
-(function () {
-  "use strict";
-  /* If the visitor's own URL carries ?token=, keep it on same-origin links.
-     The token comes from the browser's location only — never from markup. */
-  var token = new URLSearchParams(window.location.search).get("token");
-  if (!token) { return; }
-  document.querySelectorAll("a[data-token-link]").forEach(function (a) {
-    var url = new URL(a.getAttribute("href"), window.location.origin);
-    url.searchParams.set("token", token);
-    a.setAttribute("href", url.pathname + url.search);
-  });
-})();
-</script>
 {% endblock %}

--- a/healthmes/backup/remote_vault.py
+++ b/healthmes/backup/remote_vault.py
@@ -73,10 +73,18 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-# Every age v1 envelope (pyrage output included) starts with this textual
-# header; anything else is not an encrypted snapshot and must never be
-# uploaded.
+# The exact first line of every age v1 envelope (pyrage output included). The
+# guard does not merely prefix-match this — a plaintext file can start with it
+# too — it parses the surrounding header structure (see
+# ``_is_age_envelope_header``); anything else must never be uploaded.
 AGE_MAGIC = b"age-encryption.org/v1"
+
+# How much of a candidate file to read for the structural header check. An age
+# header (version line + recipient stanza(s) + ``--- <MAC>`` terminator) is a
+# few hundred bytes for our single-scrypt-recipient snapshots and stays well
+# under a kilobyte even for pathological multi-recipient headers; 16 KiB is a
+# comfortable ceiling that never touches the ciphertext body.
+_AGE_HEADER_READ = 16 * 1024
 
 DEFAULT_VAULT_PREFIX = "healthmes-vault"
 
@@ -241,6 +249,57 @@ def _file_digests(path: Path) -> tuple[str, str, int]:
     return md5.hexdigest(), sha256.hexdigest(), size
 
 
+def _is_age_envelope_header(prefix: bytes | str) -> bool:
+    """True only for a *structurally valid* age v1 header — not just the magic.
+
+    A real age v1 envelope opens with::
+
+        age-encryption.org/v1
+        -> <recipient type> <args...>
+        <base64 body line(s)>          # base64, so never begins with '-'
+        --- <base64 MAC>
+
+    Parsing that shape (rather than trusting the leading magic line) is what
+    stops a plaintext file that merely *starts* with ``age-encryption.org/v1``:
+    it has no ``-> `` recipient stanza and no ``--- <MAC>`` terminator, so it is
+    rejected. Because base64 body lines never begin with ``-``, the ``-> ``
+    stanza header and the ``--- `` MAC marker are unambiguous. ``prefix`` may be
+    a truncated read of the file — the whole header fits comfortably within it
+    (see ``_AGE_HEADER_READ``) — and the scan returns at the MAC line, so the
+    binary ciphertext body is never interpreted.
+    """
+    raw = prefix.encode("utf-8", "replace") if isinstance(prefix, str) else prefix
+    lines = raw.split(b"\n")
+    # Version line must be exactly the magic *and* be a complete line (a
+    # following newline, hence a second split element) — so a bare truncated
+    # "age-encryption.org/v1" with nothing after it does not pass.
+    if len(lines) < 2 or lines[0] != AGE_MAGIC:
+        return False
+
+    saw_recipient = False
+    index = 1
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith(b"-> "):
+            if not line[3:].strip():  # stanza header needs a recipient type
+                return False
+            saw_recipient = True
+            index += 1
+            # Consume this stanza's wrapped base64 body lines (never start '-').
+            while index < len(lines) and not lines[index].startswith(b"-"):
+                index += 1
+            continue
+        if line.startswith(b"--- "):
+            # The MAC terminator closes the header: valid only after at least
+            # one recipient stanza, and the MAC itself must be present.
+            return saw_recipient and bool(line[4:].strip())
+        # Anything else at stanza position (body lines were consumed above) is
+        # malformed — e.g. plaintext following a forged magic line.
+        return False
+    # Ran out of input before the MAC terminator: not a well-formed header.
+    return False
+
+
 class RemoteVaultProvider:
     """BackupProvider replicating encrypted snapshot envelopes to an S3 vault.
 
@@ -388,8 +447,10 @@ class RemoteVaultProvider:
 
         Defense against accidental raw-data exfiltration (PLAN section 9: no
         data export bypassing the backup seam): both the canonical snapshot
-        name *and* the age v1 header are required, so neither a stray file
-        nor a renamed plaintext database can ever reach the vault.
+        name *and* a structurally valid age v1 header are required, so neither a
+        stray file nor a renamed plaintext database — even one forged to start
+        with the literal ``age-encryption.org/v1`` magic line — can ever reach
+        the vault.
         """
         if parse_snapshot_name(path.name) is None:
             raise BackupError(
@@ -398,12 +459,12 @@ class RemoteVaultProvider:
                 "(docs/PLAN.md section 9 forbids exporting data around the backup seam)"
             )
         with path.open("rb") as handle:
-            header = handle.read(len(AGE_MAGIC))
-        if header != AGE_MAGIC:
+            header = handle.read(_AGE_HEADER_READ)
+        if not _is_age_envelope_header(header):
             raise BackupError(
                 f"refusing to upload {path.name!r}: not an age-encrypted envelope "
-                "(missing age v1 header) — only ciphertext may leave this machine "
-                "(docs/PLAN.md section 9)"
+                "(missing or malformed age v1 header) — only ciphertext may leave "
+                "this machine (docs/PLAN.md section 9)"
             )
 
     # -- vault operations ---------------------------------------------------

--- a/healthmes/calendars/__init__.py
+++ b/healthmes/calendars/__init__.py
@@ -19,6 +19,7 @@ from healthmes.calendars.base import (
     ICAL_AGENT_TASK_ID_PROPERTY,
     CalendarAuthError,
     CalendarBackend,
+    CalendarConflictError,
     CalendarError,
     EventDraft,
     EventNotFoundError,
@@ -29,8 +30,11 @@ from healthmes.calendars.base import (
 from healthmes.calendars.caldav_icloud import ICLOUD_CALDAV_URL, CalDavCalendarBackend
 from healthmes.calendars.google import GOOGLE_SCOPES, GoogleCalendarBackend
 from healthmes.calendars.state import (
+    FilePendingDiffStore,
     FileSyncStateStore,
+    InMemoryPendingDiffStore,
     InMemorySyncStateStore,
+    PendingDiffStore,
     SyncStateStore,
 )
 from healthmes.calendars.sync import (
@@ -50,6 +54,7 @@ __all__ = [
     # contract types
     "CalendarAuthError",
     "CalendarBackend",
+    "CalendarConflictError",
     "CalendarError",
     "EventDraft",
     "EventNotFoundError",
@@ -61,9 +66,12 @@ __all__ = [
     "GoogleCalendarBackend",
     "GOOGLE_SCOPES",
     "ICLOUD_CALDAV_URL",
-    # sync state persistence
+    # sync state + journal persistence
+    "FilePendingDiffStore",
     "FileSyncStateStore",
+    "InMemoryPendingDiffStore",
     "InMemorySyncStateStore",
+    "PendingDiffStore",
     "SyncStateStore",
     # mirror service / diff
     "CalendarMirrorService",

--- a/healthmes/calendars/base.py
+++ b/healthmes/calendars/base.py
@@ -37,6 +37,7 @@ __all__ = [
     "ICAL_AGENT_TASK_ID_PROPERTY",
     "CalendarAuthError",
     "CalendarBackend",
+    "CalendarConflictError",
     "CalendarError",
     "EventDraft",
     "EventNotFoundError",
@@ -83,6 +84,17 @@ class OwnershipError(CalendarError):
 
     Raised whenever a move/delete targets an event that is not agent-created
     (docs/PLAN.md section 6 ownership split).
+    """
+
+
+class CalendarConflictError(CalendarError):
+    """A conditional write lost its ``If-Match`` precondition (HTTP 412).
+
+    The event changed on the provider between the read that supplied the etag
+    and the write it guarded (a check-then-act race). Rather than blindly
+    overwriting the newer remote state, the backend refuses the write; the
+    caller re-syncs the mirror and retries against the fresh version
+    (docs/PLAN.md section 6).
     """
 
 

--- a/healthmes/calendars/google.py
+++ b/healthmes/calendars/google.py
@@ -34,6 +34,7 @@ from healthmes.calendars.base import (
     GOOGLE_AGENT_TAG_KEY,
     GOOGLE_AGENT_TASK_ID_KEY,
     CalendarAuthError,
+    CalendarConflictError,
     CalendarError,
     EventDraft,
     EventNotFoundError,
@@ -347,21 +348,55 @@ class GoogleCalendarBackend:
             body["description"] = description
         if not body:
             return current
-        patched = (
-            self._events()
-            .patch(calendarId=self._calendar_id, eventId=external_id, body=body)
-            .execute()
+        # Guard the patch with the etag we just read: if the event changed on
+        # the server in between (check-then-act race) the conditional request
+        # fails with 412 instead of silently clobbering the newer state.
+        request = self._events().patch(
+            calendarId=self._calendar_id, eventId=external_id, body=body
         )
+        self._set_if_match(request, current.etag)
+        try:
+            patched = request.execute()
+        except Exception as exc:  # noqa: BLE001 - status-based dispatch
+            self._raise_for_write_status(exc, external_id)
+            raise  # unreachable; keeps type-checkers happy about ``patched``
         return self._parse_api_event(patched)
 
     def delete_event(self, external_id: str) -> None:
-        self._get_owned_event(external_id)
+        current = self._get_owned_event(external_id)
+        request = self._events().delete(
+            calendarId=self._calendar_id, eventId=external_id
+        )
+        self._set_if_match(request, current.etag)
         try:
-            self._events().delete(calendarId=self._calendar_id, eventId=external_id).execute()
+            request.execute()
         except Exception as exc:  # noqa: BLE001 - status-based dispatch
-            if _http_status(exc) in (404, 410):
-                raise EventNotFoundError(f"google event {external_id!r} not found") from exc
-            raise
+            self._raise_for_write_status(exc, external_id)
+            raise  # unreachable; _raise_for_write_status always raises
+
+    @staticmethod
+    def _set_if_match(request: Any, etag: str | None) -> None:
+        """Attach an ``If-Match`` precondition to a googleapiclient request.
+
+        ``HttpRequest`` exposes a mutable ``headers`` dict; sending the etag
+        makes patch/delete conditional so a concurrent remote edit is rejected
+        (HTTP 412) rather than overwritten.
+        """
+        if etag:
+            request.headers["If-Match"] = etag
+
+    @staticmethod
+    def _raise_for_write_status(exc: BaseException, external_id: str) -> None:
+        """Map a patch/delete failure to the right domain error (always raises)."""
+        status = _http_status(exc)
+        if status == 412:
+            raise CalendarConflictError(
+                f"google event {external_id!r} changed on the server since it was "
+                "read (If-Match precondition failed); re-sync the mirror and retry"
+            ) from exc
+        if status in (404, 410):
+            raise EventNotFoundError(f"google event {external_id!r} not found") from exc
+        raise exc
 
     def _get_owned_event(self, external_id: str) -> ExternalEvent:
         """Fetch + parse an event, enforcing the agent-ownership tag."""

--- a/healthmes/calendars/jobs.py
+++ b/healthmes/calendars/jobs.py
@@ -31,11 +31,16 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
 from healthmes.calendars.base import CalendarBackend, EventDraft, coerce_utc
-from healthmes.calendars.state import FileSyncStateStore, SyncStateStore
-from healthmes.calendars.sync import CalendarMirrorService
+from healthmes.calendars.state import (
+    FilePendingDiffStore,
+    FileSyncStateStore,
+    PendingDiffStore,
+    SyncStateStore,
+)
+from healthmes.calendars.sync import CalendarMirrorService, SyncDiff
 from healthmes.config import Settings
 from healthmes.store.enums import CalendarSource, ProposalStatus
-from healthmes.store.models import ScheduleProposal, Task
+from healthmes.store.models import CalendarEventMirror, ScheduleProposal, Task
 from healthmes.store.session import session_scope
 
 __all__ = [
@@ -57,7 +62,7 @@ class CalendarJobSpec:
     source: CalendarSource
     job_id: str
     interval_minutes: int
-    job: Callable[[], None]
+    job: Callable[[], SyncDiff | None]
 
 
 def calendar_job_id(source: CalendarSource) -> str:
@@ -109,6 +114,38 @@ def _accepted_proposals(session: Session) -> Iterator[tuple[ScheduleProposal, Ta
     yield from ((proposal, task) for proposal, task in rows)
 
 
+def _existing_agent_block(
+    session: Session,
+    source: CalendarSource,
+    task_id: object,
+    proposal: ScheduleProposal,
+) -> CalendarEventMirror | None:
+    """Return the trusted agent mirror row already written for this proposal.
+
+    Matches an agent-created row for the same task/source whose times equal the
+    proposal's — the fingerprint of the block a prior (crashed) poll already
+    created remotely. Times are compared in Python via ``coerce_utc`` because
+    sqlite round-trips ``DateTime`` columns as naive UTC.
+    """
+    candidates = (
+        session.execute(
+            select(CalendarEventMirror).where(
+                CalendarEventMirror.calendar_source == source,
+                CalendarEventMirror.agent_task_id == task_id,
+                CalendarEventMirror.is_agent_created.is_(True),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    start = coerce_utc(proposal.proposed_start)
+    end = coerce_utc(proposal.proposed_end)
+    for row in candidates:
+        if coerce_utc(row.start_at) == start and coerce_utc(row.end_at) == end:
+            return row
+    return None
+
+
 def push_accepted_proposals(
     service: CalendarMirrorService, session: Session, source: CalendarSource
 ) -> int:
@@ -116,28 +153,39 @@ def push_accepted_proposals(
 
     Each proposal is pushed independently: the remote create commits the
     mirror row first, then the status flips to ``pushed`` and commits. A crash
-    between the two leaves the proposal ``accepted`` — the next poll retries
-    (at worst duplicating one block, never losing one). A failing backend
-    call leaves the proposal untouched for the next poll.
+    between the two leaves the proposal ``accepted`` — but the next poll now
+    detects the already-written agent block and reuses it instead of creating a
+    duplicate, so the retry is idempotent (never a second remote event, never a
+    lost one). A failing backend call leaves the proposal untouched for retry.
     """
     pushed = 0
     for proposal, task in list(_accepted_proposals(session)):
-        draft = EventDraft(
-            summary=task.title,
-            start_at=coerce_utc(proposal.proposed_start),
-            end_at=coerce_utc(proposal.proposed_end),
-            agent_task_id=task.id,
-        )
-        try:
-            row = service.create_agent_event(source, draft)
-        except Exception:
-            logger.exception(
-                "Pushing proposal %s (%s) to %s failed; retrying next poll.",
+        row = _existing_agent_block(session, source, task.id, proposal)
+        if row is None:
+            draft = EventDraft(
+                summary=task.title,
+                start_at=coerce_utc(proposal.proposed_start),
+                end_at=coerce_utc(proposal.proposed_end),
+                agent_task_id=task.id,
+            )
+            try:
+                row = service.create_agent_event(source, draft)
+            except Exception:
+                logger.exception(
+                    "Pushing proposal %s (%s) to %s failed; retrying next poll.",
+                    proposal.id,
+                    task.title,
+                    source.value,
+                )
+                continue
+        else:
+            logger.info(
+                "Proposal %s already has agent block %s on %s; finishing the "
+                "interrupted status advance instead of re-creating it.",
                 proposal.id,
-                task.title,
+                row.external_id,
                 source.value,
             )
-            continue
         proposal.status = ProposalStatus.PUSHED
         session.commit()
         pushed += 1
@@ -159,16 +207,20 @@ def build_calendar_job(
     backend_factory: Callable[[], CalendarBackend] | None = None,
     session_factory: sessionmaker[Session] | None = None,
     state_store: SyncStateStore | None = None,
-) -> Callable[[], None]:
+    pending_store: PendingDiffStore | None = None,
+) -> Callable[[], SyncDiff | None]:
     """Zero-arg poll job for one backend (collaborators injectable for tests).
 
     The backend is constructed lazily on the first run and reused (Google
     keeps an authorized service, CalDAV keeps its session); a failed
-    construction is retried on the next interval.
+    construction is retried on the next interval. The job RETURNS the run's
+    :class:`SyncDiff` (``None`` if the run failed) so the downstream
+    ``schedule_changed`` trigger can consume deletions — which vanish from the
+    mirror and so cannot be re-derived from row ``updated_at`` alone.
     """
     backend: CalendarBackend | None = None
 
-    def run_calendar_sync() -> None:
+    def run_calendar_sync() -> SyncDiff | None:
         nonlocal backend
         try:
             if backend is None:
@@ -182,15 +234,22 @@ def build_calendar_job(
                 if state_store is not None
                 else FileSyncStateStore.for_data_dir(settings.data_dir)
             )
+            journal = (
+                pending_store
+                if pending_store is not None
+                else FilePendingDiffStore.for_data_dir(settings.data_dir)
+            )
             with session_scope(session_factory) as session:
-                service = CalendarMirrorService(session, [backend], store)
-                service.sync_backend(backend)
+                service = CalendarMirrorService(session, [backend], store, journal)
+                diff = service.sync_backend(backend)
                 if is_write_backend:
                     push_accepted_proposals(service, session, source)
+                return diff
         except Exception:
             logger.exception(
                 "Calendar sync for %s failed; next interval will retry.", source.value
             )
+            return None
 
     return run_calendar_sync
 

--- a/healthmes/calendars/state.py
+++ b/healthmes/calendars/state.py
@@ -1,28 +1,92 @@
-"""Per-backend sync-state persistence (Google syncToken / CalDAV ctag+etags).
+"""Per-backend sync-state and pending-diff persistence (docs/PLAN.md §6).
 
 The mirror service treats sync state as an opaque JSON blob owned by each
-backend. Losing it is always safe — the next run performs a full window sync
-and the mirror upserts idempotently — so a small JSON file under
+backend. Losing it is always safe — the next run performs a full window sync,
+the mirror upserts idempotently, and ``_reconcile_tombstones`` recovers any
+deletions missed while the cursor was gone — so a small JSON file under
 ``Settings.data_dir`` is sufficient (local-first, survives restarts, easy to
 inspect and to wipe for a forced resync).
+
+Two concurrency hazards this module must avoid (the Google 5-minute poll and
+the CalDAV 10-minute poll can overlap in one process):
+
+- **Cross-source clobber.** State and journal live in PER-SOURCE files, never
+  one shared document, so a CalDAV write can never drop a concurrent Google
+  write — a read-modify-write of a shared file loses the other source's update.
+- **Torn temp files.** Every write goes to a UNIQUE temp name (pid + random
+  token) then ``os.replace``; two concurrent writers never collide on a fixed
+  ``.tmp`` sibling, and a crash mid-write never leaves a torn file at the
+  target path.
+
+The **pending-diff journal** closes an at-least-once gap. The mirror commit is
+idempotent, so once it lands the diff can no longer be re-derived, yet the
+cursor save (or the whole process) may still fail before the diff reaches the
+``schedule_changed`` trigger. The service journals the diff BEFORE the mirror
+commit and clears it only AFTER the cursor advances; a leftover journal is
+replayed on the next run.
 """
 
 import json
 import logging
 import os
+import uuid
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from healthmes.calendars.base import SyncState
 from healthmes.store.enums import CalendarSource
 
 __all__ = [
+    "DiffPayload",
+    "FilePendingDiffStore",
     "FileSyncStateStore",
+    "InMemoryPendingDiffStore",
     "InMemorySyncStateStore",
+    "PendingDiffStore",
     "SyncStateStore",
 ]
 
 logger = logging.getLogger(__name__)
+
+#: JSON-serializable ``SyncDiff.to_payload()`` document (journal contents).
+DiffPayload = dict[str, Any]
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    """Write ``data`` as JSON to ``path`` via a unique temp + ``os.replace``.
+
+    The temp name embeds the pid and a random token so two writers (different
+    sources, possibly different processes) never collide on a shared ``.tmp``
+    sibling; ``os.replace`` makes the swap atomic so a crash mid-write never
+    leaves a torn file at ``path``.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    tmp_path.write_text(
+        json.dumps(data, indent=2, sort_keys=True, default=str), encoding="utf-8"
+    )
+    os.replace(tmp_path, path)
+
+
+def _read_json_dict(path: Path) -> dict[str, Any] | None:
+    """Return the JSON object at ``path``; ``None`` when missing or corrupt.
+
+    A corrupted/unreadable file degrades to "never synced" (full resync)
+    instead of failing the sync loop.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("corrupted calendar state file %s; ignoring", path)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+# --- sync-state (opaque change cursor) --------------------------------------
 
 
 @runtime_checkable
@@ -60,60 +124,116 @@ class InMemorySyncStateStore:
 
 
 class FileSyncStateStore:
-    """JSON-file store keyed by calendar source, written atomically.
+    """Per-source JSON store under a directory, each file written atomically.
 
-    Layout: ``{"google": {...}, "caldav": {...}}``. Writes go through a
-    temp file + ``os.replace`` so a crash never leaves a torn file; a
-    corrupted/unreadable file degrades to "never synced" (full resync)
-    instead of failing the sync loop.
+    Layout: one file per source (``sync_state.google.json`` /
+    ``sync_state.caldav.json``) under the store directory. Separate files mean
+    overlapping polls of different sources never clobber each other, and each
+    write uses a unique temp name so concurrent writers never collide (see
+    :func:`_atomic_write_json`). A corrupted/unreadable file degrades to
+    "never synced" (full resync).
     """
 
-    def __init__(self, path: Path) -> None:
-        self._path = Path(path)
+    def __init__(self, directory: Path) -> None:
+        self._dir = Path(directory)
 
     @classmethod
     def for_data_dir(cls, data_dir: Path) -> "FileSyncStateStore":
         """Store under the local-first data dir (``Settings.data_dir``)."""
-        return cls(Path(data_dir) / "calendars" / "sync_state.json")
+        return cls(Path(data_dir) / "calendars")
 
     @property
-    def path(self) -> Path:
-        return self._path
+    def directory(self) -> Path:
+        return self._dir
+
+    def path_for(self, source: CalendarSource) -> Path:
+        """The per-source state file (never shared across sources)."""
+        return self._dir / f"sync_state.{source.value}.json"
 
     def load(self, source: CalendarSource) -> SyncState | None:
-        state = self._read_all().get(source.value)
-        return dict(state) if isinstance(state, dict) else None
+        return _read_json_dict(self.path_for(source))
 
     def save(self, source: CalendarSource, state: SyncState) -> None:
-        states = self._read_all()
-        states[source.value] = dict(state)
-        self._write_all(states)
+        _atomic_write_json(self.path_for(source), dict(state))
 
     def clear(self, source: CalendarSource | None = None) -> None:
         """Drop one source's state (or all) to force a full resync."""
         if source is None:
-            self._write_all({})
+            if self._dir.exists():
+                for stale in self._dir.glob("sync_state.*.json"):
+                    stale.unlink(missing_ok=True)
             return
-        states = self._read_all()
-        if states.pop(source.value, None) is not None:
-            self._write_all(states)
+        self.path_for(source).unlink(missing_ok=True)
 
-    def _read_all(self) -> dict[str, SyncState]:
-        try:
-            raw = self._path.read_text(encoding="utf-8")
-        except FileNotFoundError:
-            return {}
-        try:
-            data = json.loads(raw)
-        except json.JSONDecodeError:
-            logger.warning("corrupted sync-state file %s; forcing full resync", self._path)
-            return {}
-        return data if isinstance(data, dict) else {}
 
-    def _write_all(self, states: dict[str, SyncState]) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
-        tmp_path.write_text(
-            json.dumps(states, indent=2, sort_keys=True, default=str), encoding="utf-8"
-        )
-        os.replace(tmp_path, self._path)
+# --- pending-diff journal (at-least-once diff delivery) ---------------------
+
+
+@runtime_checkable
+class PendingDiffStore(Protocol):
+    """Journals one source's not-yet-delivered ``SyncDiff`` payload.
+
+    Written before the mirror commit and cleared after the cursor advances so
+    a diff whose cursor save failed is replayed (not lost) on the next run.
+    """
+
+    def load(self, source: CalendarSource) -> DiffPayload | None:
+        """Return the journaled diff payload for ``source``; ``None`` if none."""
+        ...
+
+    def save(self, source: CalendarSource, payload: DiffPayload) -> None:
+        """Persist ``payload`` as the pending diff for ``source``."""
+        ...
+
+    def clear(self, source: CalendarSource) -> None:
+        """Drop the pending diff for ``source`` (delivery confirmed)."""
+        ...
+
+
+class InMemoryPendingDiffStore:
+    """Dict-backed journal for tests and one-off tooling (deep-copies on I/O)."""
+
+    def __init__(self) -> None:
+        self._payloads: dict[str, DiffPayload] = {}
+
+    def load(self, source: CalendarSource) -> DiffPayload | None:
+        payload = self._payloads.get(source.value)
+        return json.loads(json.dumps(payload)) if payload is not None else None
+
+    def save(self, source: CalendarSource, payload: DiffPayload) -> None:
+        self._payloads[source.value] = json.loads(json.dumps(payload, default=str))
+
+    def clear(self, source: CalendarSource) -> None:
+        self._payloads.pop(source.value, None)
+
+
+class FilePendingDiffStore:
+    """Per-source JSON journal under a directory (``pending_diff.<source>.json``).
+
+    Uses the same per-source + unique-temp-name discipline as
+    :class:`FileSyncStateStore` so the two enabled backends never clobber each
+    other's journal.
+    """
+
+    def __init__(self, directory: Path) -> None:
+        self._dir = Path(directory)
+
+    @classmethod
+    def for_data_dir(cls, data_dir: Path) -> "FilePendingDiffStore":
+        return cls(Path(data_dir) / "calendars")
+
+    @property
+    def directory(self) -> Path:
+        return self._dir
+
+    def path_for(self, source: CalendarSource) -> Path:
+        return self._dir / f"pending_diff.{source.value}.json"
+
+    def load(self, source: CalendarSource) -> DiffPayload | None:
+        return _read_json_dict(self.path_for(source))
+
+    def save(self, source: CalendarSource, payload: DiffPayload) -> None:
+        _atomic_write_json(self.path_for(source), payload)
+
+    def clear(self, source: CalendarSource) -> None:
+        self.path_for(source).unlink(missing_ok=True)

--- a/healthmes/calendars/sync.py
+++ b/healthmes/calendars/sync.py
@@ -41,7 +41,7 @@ from healthmes.calendars.base import (
     coerce_utc,
     ensure_utc,
 )
-from healthmes.calendars.state import SyncStateStore
+from healthmes.calendars.state import PendingDiffStore, SyncStateStore
 from healthmes.store.enums import CalendarSource
 from healthmes.store.models import CalendarEventMirror, Task
 
@@ -79,7 +79,7 @@ class EventChange:
     new_end_at: datetime | None = None
 
     def to_payload(self) -> dict[str, object]:
-        """JSON-safe dict for trigger payloads / webhook bodies."""
+        """JSON-safe dict for trigger payloads / webhook bodies / the journal."""
         payload = asdict(self)
         payload["calendar_source"] = self.calendar_source.value
         payload["kind"] = self.kind.value
@@ -87,6 +87,27 @@ class EventChange:
             value = payload[key]
             payload[key] = value.isoformat() if isinstance(value, datetime) else None
         return payload
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, object]) -> "EventChange":
+        """Inverse of :meth:`to_payload` (journal replay round-trip)."""
+
+        def _dt(key: str) -> datetime | None:
+            value = payload.get(key)
+            return datetime.fromisoformat(value) if isinstance(value, str) else None
+
+        summary = payload.get("summary")
+        return cls(
+            calendar_source=CalendarSource(payload["calendar_source"]),
+            external_id=str(payload["external_id"]),
+            kind=ChangeKind(payload["kind"]),
+            summary=summary if isinstance(summary, str) else None,
+            is_agent_created=bool(payload["is_agent_created"]),
+            old_start_at=_dt("old_start_at"),
+            old_end_at=_dt("old_end_at"),
+            new_start_at=_dt("new_start_at"),
+            new_end_at=_dt("new_end_at"),
+        )
 
 
 @dataclass(slots=True)
@@ -115,13 +136,28 @@ class SyncDiff:
         self.agent_modified.extend(other.agent_modified)
 
     def to_payload(self) -> dict[str, object]:
-        """JSON-safe dict for trigger payloads / webhook bodies."""
+        """JSON-safe dict for trigger payloads / webhook bodies / the journal."""
         return {
             "created": [change.to_payload() for change in self.created],
             "moved": [change.to_payload() for change in self.moved],
             "deleted": [change.to_payload() for change in self.deleted],
             "agent_modified": [change.to_payload() for change in self.agent_modified],
         }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, object]) -> "SyncDiff":
+        """Inverse of :meth:`to_payload` — rebuild a diff from the journal."""
+
+        def _changes(key: str) -> list[EventChange]:
+            raw = payload.get(key) or []
+            return [EventChange.from_payload(item) for item in raw]  # type: ignore[arg-type]
+
+        return cls(
+            created=_changes("created"),
+            moved=_changes("moved"),
+            deleted=_changes("deleted"),
+            agent_modified=_changes("agent_modified"),
+        )
 
 
 class CalendarMirrorService:
@@ -138,6 +174,7 @@ class CalendarMirrorService:
         session: Session,
         backends: Iterable[CalendarBackend],
         state_store: SyncStateStore,
+        pending_store: PendingDiffStore | None = None,
     ) -> None:
         self._session = session
         self._backends: dict[CalendarSource, CalendarBackend] = {}
@@ -146,6 +183,7 @@ class CalendarMirrorService:
                 raise CalendarError(f"duplicate backend for source {backend.source.value!r}")
             self._backends[backend.source] = backend
         self._state_store = state_store
+        self._pending_store = pending_store
 
     # -- pull / diff -------------------------------------------------------
 
@@ -161,19 +199,44 @@ class CalendarMirrorService:
         source = backend.source
         previous_state = self._state_store.load(source)
         bootstrap = previous_state is None
+        # Carry forward any diff a previous run journaled but never delivered
+        # (its cursor save failed after the idempotent mirror commit landed).
+        replayed = self._load_pending(source)
         events, new_state = backend.list_changes(previous_state)
 
         diff = SyncDiff()
+        seen_ids: set[str] = set()
         for event in events:
+            seen_ids.add(event.external_id)
             if event.deleted:
                 self._apply_deletion(source, event, diff)
             else:
                 self._apply_upsert(source, event, diff, bootstrap=bootstrap)
 
-        # Commit rows first, then persist the cursor: a crash in between
-        # re-delivers the same changes, and upserts are idempotent.
+        if bootstrap:
+            # A lost/emptied cursor forces a full-window fetch; mirror rows the
+            # provider no longer returns were deleted (or slid out of the
+            # scheduling window) while we had no cursor — emit tombstones so the
+            # deletion is not lost forever (docs/PLAN.md §6).
+            self._reconcile_tombstones(source, seen_ids, diff)
+
+        if replayed is not None:
+            merged = SyncDiff()
+            merged.extend(replayed)
+            merged.extend(diff)
+            diff = merged
+
+        # Journal the diff BEFORE the mirror commit: once the idempotent upserts
+        # land, the diff can no longer be re-derived, so a crash between the
+        # commit and the cursor save would otherwise lose a deletion/move the
+        # trigger must consume. Cleared only AFTER the cursor advances, so a
+        # failed cursor save replays it next run (at-least-once; the trigger
+        # dedups replays).
+        if diff.has_changes:
+            self._save_pending(source, diff)
         self._session.commit()
         self._state_store.save(source, new_state)
+        self._clear_pending(source)
         if diff.has_changes:
             logger.info(
                 "calendar sync %s: +%d created, %d moved, -%d deleted, %d agent-modified",
@@ -185,6 +248,20 @@ class CalendarMirrorService:
             )
         return diff
 
+    def _load_pending(self, source: CalendarSource) -> SyncDiff | None:
+        if self._pending_store is None:
+            return None
+        payload = self._pending_store.load(source)
+        return SyncDiff.from_payload(payload) if payload else None
+
+    def _save_pending(self, source: CalendarSource, diff: SyncDiff) -> None:
+        if self._pending_store is not None:
+            self._pending_store.save(source, diff.to_payload())
+
+    def _clear_pending(self, source: CalendarSource) -> None:
+        if self._pending_store is not None:
+            self._pending_store.clear(source)
+
     def _apply_upsert(
         self,
         source: CalendarSource,
@@ -194,6 +271,15 @@ class CalendarMirrorService:
         bootstrap: bool,
     ) -> None:
         assert event.start_at is not None and event.end_at is not None  # live event
+        resolved_task_id = self._resolve_task_id(event.agent_task_id)
+        # An incoming provider event is trusted as agent-created ONLY when it
+        # carries the ownership tag AND a task id that resolves to a local Task
+        # row. A forged tag alone (or a tag whose task id we never had) must
+        # never grant the agent write authority over an event the external
+        # calendar really owns — otherwise a hand-crafted ``healthmes=1`` on
+        # someone else's meeting would let the agent move/delete it.
+        trusted_agent = bool(event.is_agent_created) and resolved_task_id is not None
+
         row = self._get_row(source, event.external_id)
         if row is None:
             self._session.add(
@@ -203,15 +289,16 @@ class CalendarMirrorService:
                     summary=event.summary,
                     start_at=event.start_at,
                     end_at=event.end_at,
-                    is_agent_created=event.is_agent_created,
-                    agent_task_id=self._resolve_task_id(event.agent_task_id),
+                    is_agent_created=trusted_agent,
+                    agent_task_id=resolved_task_id if trusted_agent else None,
                     etag=event.etag,
                 )
             )
-            # Agent-tagged events without a row are re-adopted silently (the
-            # row normally pre-exists from create_agent_event); bootstrap
-            # adopts everything silently.
-            if not bootstrap and not event.is_agent_created:
+            # Trusted agent-tagged events without a row are re-adopted silently
+            # (the row normally pre-exists from create_agent_event); bootstrap
+            # adopts everything silently. A forged/untrusted tag is treated as
+            # the genuine external creation it is.
+            if not bootstrap and not trusted_agent:
                 diff.created.append(
                     EventChange(
                         calendar_source=source,
@@ -229,14 +316,19 @@ class CalendarMirrorService:
         old_end = coerce_utc(row.end_at)
         moved = old_start != event.start_at or old_end != event.end_at
         content_changed = (row.summary or None) != (event.summary or None)
+        # Refresh ownership from the freshly-observed provider state: if the tag
+        # was stripped (or its task link no longer resolves) the row flips to
+        # external, and what would have been an agent-move is reclassified into
+        # the external ``diff.moved`` bucket below.
+        ownership_changed = row.is_agent_created != trusted_agent
 
-        if not moved and not content_changed:
-            # Byte-identical re-delivery (410 full resync, lost sync-state
-            # file, crash between commit and cursor save): write NOTHING.
-            # Assigning equal values still dirties the row on sqlite (stored
-            # datetimes load naive, event values are aware), and any UPDATE
-            # bumps updated_at — which the trigger sweep reads as an external
-            # change (triggers.py::_load_schedule_changes contract:
+        if not moved and not content_changed and not ownership_changed:
+            # Byte-identical, same-tag re-delivery (410 full resync, lost
+            # sync-state file, crash between commit and cursor save): write
+            # NOTHING. Assigning equal values still dirties the row on sqlite
+            # (stored datetimes load naive, event values are aware), and any
+            # UPDATE bumps updated_at — which the trigger sweep reads as an
+            # external change (triggers.py::_load_schedule_changes contract:
             # updated_at moves only when the event actually changed).
             return
 
@@ -245,21 +337,21 @@ class CalendarMirrorService:
         row.start_at = event.start_at
         row.end_at = event.end_at
         row.etag = event.etag
-        if row.agent_task_id is None and event.agent_task_id is not None:
-            row.agent_task_id = self._resolve_task_id(event.agent_task_id)
+        row.is_agent_created = trusted_agent
+        row.agent_task_id = resolved_task_id if trusted_agent else None
 
         change = EventChange(
             calendar_source=source,
             external_id=event.external_id,
             kind=ChangeKind.MOVED if moved else ChangeKind.MODIFIED,
             summary=event.summary,
-            is_agent_created=row.is_agent_created,
+            is_agent_created=trusted_agent,
             old_start_at=old_start,
             old_end_at=old_end,
             new_start_at=event.start_at,
             new_end_at=event.end_at,
         )
-        if row.is_agent_created:
+        if trusted_agent:
             diff.agent_modified.append(change)
         elif moved:
             diff.moved.append(change)
@@ -286,6 +378,40 @@ class CalendarMirrorService:
             diff.agent_modified.append(change)
         else:
             diff.deleted.append(change)
+
+    def _reconcile_tombstones(
+        self, source: CalendarSource, seen_ids: set[str], diff: SyncDiff
+    ) -> None:
+        """Tombstone mirror rows the provider no longer returns on a full resync.
+
+        Only runs on bootstrap (sync state None/empty), when the backend fetches
+        the whole current window. Any pre-existing mirror row for this source
+        absent from that fresh set was deleted — or slid past the scheduling
+        window — while we had no cursor to observe the deletion notice. Without a
+        tombstone the mirror keeps a stale row forever and the ``schedule_changed``
+        trigger never learns of the deletion (docs/PLAN.md §6). A true first-ever
+        sync has an empty mirror, so this reconcile is a silent no-op then.
+        """
+        statement = select(CalendarEventMirror).where(
+            CalendarEventMirror.calendar_source == source
+        )
+        for row in self._session.execute(statement).scalars().all():
+            if row.external_id in seen_ids:
+                continue  # freshly upserted, or already handled as a deletion
+            change = EventChange(
+                calendar_source=source,
+                external_id=row.external_id,
+                kind=ChangeKind.DELETED,
+                summary=row.summary,
+                is_agent_created=row.is_agent_created,
+                old_start_at=coerce_utc(row.start_at),
+                old_end_at=coerce_utc(row.end_at),
+            )
+            self._session.delete(row)
+            if change.is_agent_created:
+                diff.agent_modified.append(change)
+            else:
+                diff.deleted.append(change)
 
     # -- ownership-guarded agent writes -------------------------------------
 

--- a/healthmes/config.py
+++ b/healthmes/config.py
@@ -11,12 +11,15 @@ Never hardcode docker service hostnames here.
 
 import datetime
 import ipaddress
+import logging
 import zoneinfo
 from functools import lru_cache
 from pathlib import Path
 
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
@@ -302,6 +305,34 @@ def get_settings() -> Settings:
     return Settings()
 
 
+def system_timezone() -> datetime.tzinfo:
+    """Return the machine's IANA timezone, never a captured local offset."""
+    try:
+        from tzlocal import get_localzone
+
+        local = get_localzone()
+        if isinstance(local, zoneinfo.ZoneInfo):
+            return local
+        key = getattr(local, "key", None)
+        if key:
+            return zoneinfo.ZoneInfo(str(key))
+    except Exception:
+        logger.debug("tzlocal could not resolve the system timezone", exc_info=True)
+
+    try:
+        target = Path("/etc/localtime").resolve(strict=True)
+        parts = target.parts
+        zoneinfo_index = parts.index("zoneinfo")
+        name = "/".join(parts[zoneinfo_index + 1 :])
+        if name:
+            return zoneinfo.ZoneInfo(name)
+    except (OSError, ValueError, zoneinfo.ZoneInfoNotFoundError):
+        logger.debug("/etc/localtime did not resolve to an IANA timezone", exc_info=True)
+
+    logger.warning("Could not resolve the system IANA timezone; falling back to UTC")
+    return datetime.UTC
+
+
 def resolve_timezone(settings: Settings) -> datetime.tzinfo:
     """The user's local timezone: ``Settings.timezone`` (IANA) or the machine's.
 
@@ -315,9 +346,7 @@ def resolve_timezone(settings: Settings) -> datetime.tzinfo:
     name = getattr(settings, "timezone", None)
     if name:
         return zoneinfo.ZoneInfo(str(name))
-    local = datetime.datetime.now().astimezone().tzinfo
-    assert local is not None  # astimezone() always attaches a tzinfo
-    return local
+    return system_timezone()
 
 
 def is_loopback_host(host: str) -> bool:

--- a/healthmes/engine/triggers.py
+++ b/healthmes/engine/triggers.py
@@ -675,7 +675,16 @@ class TriggerEvaluator:
             event.payload = {**payload, "push": {"suppressed_reason": reason}}
             return FireOutcome(fire=fire, status="suppressed", reason=reason)
 
-        result = self._alert_sender.send(fire, fired_at=now)
+        try:
+            result = self._alert_sender.send(fire, fired_at=now)
+        except Exception as exc:
+            # The sender *raised* (transport blew up mid-send) rather than
+            # returning a clean WebhookResult(ok=False) — that latter case is a
+            # gateway that answered non-2xx and is handled below. The
+            # trigger_event row is already flushed (its dedup key is burned), so
+            # a raised send must be unwound; see _handle_send_exception.
+            return self._handle_send_exception(session, fire, event, payload, exc)
+
         if result.ok:
             event.alert_sent = True
             event.payload = {
@@ -710,6 +719,47 @@ class TriggerEvaluator:
             },
         }
         return FireOutcome(fire=fire, status="push_failed", reason=result.detail)
+
+    def _handle_send_exception(
+        self,
+        session: Session,
+        fire: TriggerFire,
+        event: TriggerEvent,
+        payload: dict[str, Any],
+        exc: Exception,
+    ) -> FireOutcome:
+        """Recover a fire whose AlertSender.send() *raised* (not a clean non-2xx).
+
+        The ``trigger_event`` row was already ``add``-ed and ``flush``-ed above,
+        so its dedup key is burned; without unwinding, a transport that raises
+        would permanently swallow the alert. Two recoveries:
+
+        - ``native_alert_delivery`` on: the alert is still surfaced to the
+          companion apps via /v1/alerts + glance polling, so mark it delivered
+          natively (the phone/watch get it without Telegram) and keep the row.
+        - native off: the alert is genuinely undelivered and MUST retry on the
+          next sweep, so the burned dedup key has to go. ``session.expunge`` is
+          NOT enough here — the INSERT already emitted at flush, so expunge only
+          detaches the instance while the row still commits; only
+          ``delete`` + ``flush`` actually removes it, letting the identical fire
+          re-fire (its dedup key was never truly recorded).
+        """
+        if self._settings.native_alert_delivery:
+            event.alert_sent = True
+            event.payload = {
+                **payload,
+                "push": {
+                    "sent": True,
+                    "channel": "native",
+                    "webhook_ok": False,
+                    "webhook_error": str(exc),
+                },
+            }
+            return FireOutcome(fire=fire, status="pushed")
+
+        session.delete(event)
+        session.flush()
+        return FireOutcome(fire=fire, status="push_failed", reason=str(exc))
 
     def _push_suppression_reason(
         self, session: Session, now: datetime, fire: TriggerFire

--- a/healthmes/mcp_server/interpret.py
+++ b/healthmes/mcp_server/interpret.py
@@ -46,6 +46,8 @@ MIN_SLEEP_DEBT_NIGHTS = 3
 
 # A daily stress/resilience reading older than this is not "today's" state.
 STRESS_MAX_STALE_DAYS = 3
+# Nocturnal HRV older than this is not a current readiness observation.
+HRV_MAX_STALE_DAYS = 3
 
 STATUS_OK = "ok"
 STATUS_INSUFFICIENT = "insufficient_data"
@@ -131,6 +133,7 @@ def metric_baseline(
     *,
     window_days: int = BASELINE_WINDOW_DAYS,
     min_days: int = MIN_BASELINE_DAYS,
+    max_stale_days: int | None = None,
 ) -> dict[str, Any]:
     """Current value vs trailing-median baseline for one daily metric.
 
@@ -165,6 +168,12 @@ def metric_baseline(
         "coverage": coverage_ratio(n_days, window_days),
         "confidence": confidence_label(n_days, window_days),
     }
+    stale_days = (as_of - current_day).days
+    if max_stale_days is not None and stale_days > max_stale_days:
+        result["status"] = STATUS_INSUFFICIENT
+        result["reason"] = f"current_reading_stale_gt_{max_stale_days}_days"
+        result["stale_days"] = stale_days
+        return result
     if n_days < min_days:
         result["status"] = STATUS_INSUFFICIENT
         result["reason"] = f"need_at_least_{min_days}_baseline_days"
@@ -283,6 +292,32 @@ def stress_context(
         "reason": "no_garmin_stress_and_no_internal_resilience_within_window",
         "confidence": "low",
     }
+
+
+def choose_stress_series(
+    garmin_by_day: Mapping[date, float],
+    proxy_by_day: Mapping[date, float],
+    as_of: date,
+    *,
+    max_stale_days: int = STRESS_MAX_STALE_DAYS,
+) -> tuple[dict[date, float], str]:
+    """Choose one complete stress series without mixing providers."""
+
+    def _latest(series: Mapping[date, float]) -> date | None:
+        candidates = [day for day in series if day <= as_of]
+        return max(candidates) if candidates else None
+
+    garmin_day = _latest(garmin_by_day)
+    proxy_day = _latest(proxy_by_day)
+    if garmin_day is not None and (as_of - garmin_day).days <= max_stale_days:
+        return dict(garmin_by_day), "garmin"
+    if proxy_day is not None and (as_of - proxy_day).days <= max_stale_days:
+        return dict(proxy_by_day), "proxy"
+    if garmin_day is None and proxy_day is None:
+        return {}, "none"
+    if proxy_day is None or (garmin_day is not None and garmin_day >= proxy_day):
+        return dict(garmin_by_day), "garmin"
+    return dict(proxy_by_day), "proxy"
 
 
 def overall_confidence(blocks: Iterable[Mapping[str, Any]]) -> str:

--- a/healthmes/mcp_server/ow_client.py
+++ b/healthmes/mcp_server/ow_client.py
@@ -166,9 +166,30 @@ class OWClient:
         provider: str | None = None,
     ) -> list[dict[str, Any]]:
         """All health-score rows in a window, following offset pagination."""
+        rows, _truncated = await self.collect_health_scores_tracked(
+            user_id,
+            start_date=start_date,
+            end_date=end_date,
+            category=category,
+            provider=provider,
+        )
+        return rows
+
+    async def collect_health_scores_tracked(
+        self,
+        user_id: str,
+        *,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        category: str | None = None,
+        provider: str | None = None,
+        max_pages: int = MAX_PAGES,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Like :meth:`collect_health_scores`, plus a truncation flag."""
         rows: list[dict[str, Any]] = []
         offset = 0
-        for _ in range(MAX_PAGES):
+        has_more = False
+        for _ in range(max_pages):
             payload = await self.get_health_scores(
                 user_id,
                 start_date=start_date,
@@ -180,10 +201,16 @@ class OWClient:
             data = payload.get("data", [])
             rows.extend(data)
             pagination = payload.get("pagination", {})
-            if not pagination.get("has_more") or not data:
-                break
+            has_more = bool(pagination.get("has_more"))
+            if not has_more or not data:
+                return rows, False
             offset += len(data)
-        return rows
+        if has_more:
+            logger.warning(
+                "offset pagination stopped at max_pages=%d with more data available",
+                max_pages,
+            )
+        return rows, has_more
 
     # ------------------------------------------------------------------
     # Summaries (routes/v1/summaries.py — cursor pagination)
@@ -241,23 +268,51 @@ class OWClient:
         self, user_id: str, start_date: str, end_date: str
     ) -> list[dict[str, Any]]:
         """All daily sleep summaries in a window, following cursor pagination."""
-        rows, _ = await self._collect_cursor(
-            lambda cursor: self.get_sleep_summaries(
-                user_id, start_date, end_date, cursor=cursor
-            )
+        rows, _truncated = await self.collect_sleep_summaries_tracked(
+            user_id, start_date, end_date
         )
         return rows
+
+    async def collect_sleep_summaries_tracked(
+        self,
+        user_id: str,
+        start_date: str,
+        end_date: str,
+        *,
+        max_pages: int = MAX_PAGES,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Like :meth:`collect_sleep_summaries`, plus a truncation flag."""
+        return await self._collect_cursor(
+            lambda cursor: self.get_sleep_summaries(
+                user_id, start_date, end_date, cursor=cursor
+            ),
+            max_pages=max_pages,
+        )
 
     async def collect_recovery_summaries(
         self, user_id: str, start_date: str, end_date: str
     ) -> list[dict[str, Any]]:
         """All daily recovery summaries in a window, following cursor pagination."""
-        rows, _ = await self._collect_cursor(
-            lambda cursor: self.get_recovery_summaries(
-                user_id, start_date, end_date, cursor=cursor
-            )
+        rows, _truncated = await self.collect_recovery_summaries_tracked(
+            user_id, start_date, end_date
         )
         return rows
+
+    async def collect_recovery_summaries_tracked(
+        self,
+        user_id: str,
+        start_date: str,
+        end_date: str,
+        *,
+        max_pages: int = MAX_PAGES,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Like :meth:`collect_recovery_summaries`, plus a truncation flag."""
+        return await self._collect_cursor(
+            lambda cursor: self.get_recovery_summaries(
+                user_id, start_date, end_date, cursor=cursor
+            ),
+            max_pages=max_pages,
+        )
 
     # ------------------------------------------------------------------
     # Events (routes/v1/events.py — cursor pagination)
@@ -290,12 +345,27 @@ class OWClient:
         record_type: str | None = None,
     ) -> list[dict[str, Any]]:
         """All workouts in a window, following cursor pagination."""
-        rows, _ = await self._collect_cursor(
-            lambda cursor: self.get_workouts(
-                user_id, start_date, end_date, record_type=record_type, cursor=cursor
-            )
+        rows, _truncated = await self.collect_workouts_tracked(
+            user_id, start_date, end_date, record_type=record_type
         )
         return rows
+
+    async def collect_workouts_tracked(
+        self,
+        user_id: str,
+        start_date: str,
+        end_date: str,
+        *,
+        record_type: str | None = None,
+        max_pages: int = MAX_PAGES,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Like :meth:`collect_workouts`, plus a truncation flag."""
+        return await self._collect_cursor(
+            lambda cursor: self.get_workouts(
+                user_id, start_date, end_date, record_type=record_type, cursor=cursor
+            ),
+            max_pages=max_pages,
+        )
 
     async def get_menstrual_cycles(
         self,
@@ -323,12 +393,26 @@ class OWClient:
         self, user_id: str, start_date: str, end_date: str
     ) -> list[dict[str, Any]]:
         """All menstrual-cycle records in a window, following cursor pagination."""
-        rows, _ = await self._collect_cursor(
-            lambda cursor: self.get_menstrual_cycles(
-                user_id, start_date, end_date, cursor=cursor
-            )
+        rows, _truncated = await self.collect_menstrual_cycles_tracked(
+            user_id, start_date, end_date
         )
         return rows
+
+    async def collect_menstrual_cycles_tracked(
+        self,
+        user_id: str,
+        start_date: str,
+        end_date: str,
+        *,
+        max_pages: int = MAX_PAGES,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Like :meth:`collect_menstrual_cycles`, plus a truncation flag."""
+        return await self._collect_cursor(
+            lambda cursor: self.get_menstrual_cycles(
+                user_id, start_date, end_date, cursor=cursor
+            ),
+            max_pages=max_pages,
+        )
 
     async def get_sleep_sessions(
         self,

--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -56,7 +56,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
-from healthmes.config import Settings, get_settings
+from healthmes.config import Settings, get_settings, system_timezone
 from healthmes.mcp_server import impact, interpret, timeline
 from healthmes.mcp_server.ow_client import OWClient, OWClientError, resolve_single_user_id
 from healthmes.store import (
@@ -118,6 +118,8 @@ MAX_TREE_NODES = 500
 
 _RANGE_PATTERN = re.compile(r"^(\d{1,3})d$")
 MAX_RANGE_DAYS = 90
+MIN_AGG_DAYS_WITH_DATA = 3
+MIN_TIMELINE_SAMPLES = 3
 
 mcp: FastMCP = FastMCP(
     "healthmes",
@@ -271,9 +273,7 @@ def _local_timezone() -> dt.tzinfo:
                 f"Configured timezone {name!r} is not a valid IANA name "
                 "(HEALTHMES_TIMEZONE, e.g. 'Asia/Seoul')."
             ) from exc
-    local = dt.datetime.now().astimezone().tzinfo
-    assert local is not None
-    return local
+    return system_timezone()
 
 
 def _build_energy_engine() -> Any:
@@ -408,8 +408,15 @@ _summary_daily_values = interpret.summary_daily_values
 async def _fetch_health_scores(
     user_id: str, start: dt.date, end_exclusive: dt.date
 ) -> list[dict[str, Any]]:
+    rows, _truncated = await _fetch_health_scores_tracked(user_id, start, end_exclusive)
+    return rows
+
+
+async def _fetch_health_scores_tracked(
+    user_id: str, start: dt.date, end_exclusive: dt.date
+) -> tuple[list[dict[str, Any]], bool]:
     client = get_ow_client()
-    return await client.collect_health_scores(
+    return await client.collect_health_scores_tracked(
         user_id, start_date=start.isoformat(), end_date=end_exclusive.isoformat()
     )
 
@@ -470,7 +477,9 @@ async def get_health_scores(
         )
 
     user_id = await _resolve_user_id()
-    rows = await _fetch_health_scores(user_id, start_day, end_day + dt.timedelta(days=1))
+    rows, truncated = await _fetch_health_scores_tracked(
+        user_id, start_day, end_day + dt.timedelta(days=1)
+    )
 
     groups: dict[str, dict[str, Any]] = {}
     for row in rows:
@@ -533,8 +542,17 @@ async def get_health_scores(
             "confidence": interpret.confidence_label(len(by_day), days),
         }
 
+    best_days = max(
+        (group["days_with_data"] for group in scores.values()),
+        default=0,
+    )
+    enough_data = bool(scores) and best_days >= min(MIN_AGG_DAYS_WITH_DATA, days)
     return {
-        "status": interpret.STATUS_OK if scores else interpret.STATUS_INSUFFICIENT,
+        "status": (
+            interpret.STATUS_OK
+            if enough_data and not truncated
+            else interpret.STATUS_INSUFFICIENT
+        ),
         "window": {
             "start_date": start_day.isoformat(),
             "end_date": end_day.isoformat(),
@@ -542,6 +560,7 @@ async def get_health_scores(
         },
         "categories_requested": list(requested),
         "scores": scores,
+        "truncated": truncated,
     }
 
 
@@ -559,7 +578,8 @@ async def get_daily_readiness_context(date: str | None = None) -> dict[str, Any]
     of guessing; overall confidence is the weakest confirmed block. `date` is
     ISO YYYY-MM-DD, default today in the user's timezone.
     """
-    as_of = _parse_date(date, "date")
+    tz = _local_timezone()
+    as_of = _parse_date_local(date, "date", tz)
     fetch_start = as_of - dt.timedelta(days=interpret.BASELINE_WINDOW_DAYS + 7)
     end_exclusive = as_of + dt.timedelta(days=1)
     user_id = await _resolve_user_id()
@@ -574,10 +594,19 @@ async def get_daily_readiness_context(date: str | None = None) -> dict[str, Any]
     )
 
     # --- sleep debt (internal sleep score; algorithms/sleep.py, never reinvented)
-    sleep_scores, sleep_source = _sleep_score_series(score_rows)
-    sleep_block = interpret.sleep_debt(sleep_scores, as_of)
-    if sleep_source:
-        sleep_block["source"] = sleep_source
+    internal_scores = interpret.daily_series(
+        _localized(_score_points(score_rows, "sleep", provider="internal"), tz),
+        how="max",
+    )
+    if internal_scores:
+        sleep_block = interpret.sleep_debt(internal_scores, as_of)
+        sleep_block["source"] = "internal_sleep_score"
+    else:
+        sleep_block = {
+            "status": interpret.STATUS_INSUFFICIENT,
+            "reason": "no_internal_sleep_score",
+            "confidence": "low",
+        }
 
     # --- nocturnal HRV vs 14-day baseline (variant-separated, never mixed)
     rmssd = _summary_daily_values(sleep_rows, "avg_hrv_rmssd_ms", as_of)
@@ -585,7 +614,11 @@ async def get_daily_readiness_context(date: str | None = None) -> dict[str, Any]
     if rmssd or sdnn:
         variant = "rmssd" if len(rmssd) >= len(sdnn) else "sdnn"
         series = rmssd if variant == "rmssd" else sdnn
-        hrv_block = interpret.metric_baseline(series, as_of)
+        hrv_block = interpret.metric_baseline(
+            series,
+            as_of,
+            max_stale_days=interpret.HRV_MAX_STALE_DAYS,
+        )
         hrv_block["variant"] = variant
         hrv_block["unit"] = "ms"
         hrv_block["source"] = "nocturnal (sleep summaries)"
@@ -598,9 +631,13 @@ async def get_daily_readiness_context(date: str | None = None) -> dict[str, Any]
 
     # --- stress (Garmin native, else internal resilience proxy)
     garmin_stress = interpret.daily_series(
-        _score_points(score_rows, "stress", provider="garmin"), how="mean"
+        _localized(_score_points(score_rows, "stress", provider="garmin"), tz),
+        how="mean",
     )
-    resilience = interpret.daily_series(_resilience_score_points(score_rows), how="latest")
+    resilience = interpret.daily_series(
+        _localized(_resilience_score_points(score_rows), tz),
+        how="latest",
+    )
     stress_block = interpret.stress_context(garmin_stress, resilience, as_of)
 
     # --- charge scores (freshest body_battery / readiness / recovery)
@@ -610,7 +647,10 @@ async def get_daily_readiness_context(date: str | None = None) -> dict[str, Any]
             (recorded_at, value, row)
             for row in score_rows
             if row.get("category") == category
-            for recorded_at, value in _score_points([row], category)
+            for recorded_at, value in _localized(
+                _score_points([row], category),
+                tz,
+            )
             if (as_of - recorded_at.date()).days in (0, 1)
         ]
         if not candidates:
@@ -709,7 +749,8 @@ async def get_personal_baselines(
         raise ToolError(
             f"Unknown metrics {unknown}; supported: {sorted(_BASELINE_METRICS)}"
         )
-    anchor = _parse_date(as_of, "as_of")
+    tz = _local_timezone()
+    anchor = _parse_date_local(as_of, "as_of", tz)
     fetch_start = anchor - dt.timedelta(days=interpret.LONG_BASELINE_WINDOW_DAYS + 1)
     end_exclusive = anchor + dt.timedelta(days=1)
     user_id = await _resolve_user_id()
@@ -739,19 +780,31 @@ async def get_personal_baselines(
         elif source == "recovery_summaries":
             daily = _summary_daily_values(recovery_rows, field, anchor)
         elif field == "sleep":
-            daily, sleep_source = _sleep_score_series(score_rows)
+            daily, sleep_source = _sleep_score_series(score_rows, tz=tz)
             source_label = sleep_source or "health_scores.sleep"
         else:  # stress: Garmin native, else internal resilience proxy
-            daily = interpret.daily_series(
-                _score_points(score_rows, "stress", provider="garmin"), how="mean"
+            garmin_daily = interpret.daily_series(
+                _localized(_score_points(score_rows, "stress", provider="garmin"), tz),
+                how="mean",
             )
-            source_label = "health_scores.stress(garmin)"
-            if not daily:
-                resilience = interpret.daily_series(
-                    _resilience_score_points(score_rows), how="latest"
-                )
-                daily = {day: 100.0 - score for day, score in resilience.items()}
-                source_label = "internal_resilience_proxy(100-resilience_score)"
+            resilience_daily = interpret.daily_series(
+                _localized(_resilience_score_points(score_rows), tz),
+                how="latest",
+            )
+            proxy_daily = {
+                day: max(0.0, min(100.0, 100.0 - score))
+                for day, score in resilience_daily.items()
+            }
+            daily, which = interpret.choose_stress_series(
+                garmin_daily,
+                proxy_daily,
+                anchor,
+            )
+            source_label = {
+                "garmin": "health_scores.stress(garmin)",
+                "proxy": "internal_resilience_proxy(100-resilience_score)",
+                "none": "health_scores.stress(garmin)",
+            }[which]
 
         entry = interpret.metric_baseline(daily, anchor)
         entry["unit"] = unit
@@ -952,7 +1005,7 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
     user_id = await _resolve_user_id()
     client = get_ow_client()
 
-    series_rows = await client.collect_timeseries(
+    series_rows, series_truncated = await client.collect_timeseries_tracked(
         user_id, start_utc.isoformat(), end_utc.isoformat(), [STRESS_SERIES_TYPE]
     )
     samples_utc = [
@@ -960,6 +1013,28 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
         for recorded_at, value in _stress_samples(series_rows)
         if start_utc <= recorded_at < end_utc
     ]
+
+    if samples_utc and len(samples_utc) < MIN_TIMELINE_SAMPLES and not series_truncated:
+        return {
+            "status": interpret.STATUS_INSUFFICIENT,
+            "date": day.isoformat(),
+            "timezone": str(tz),
+            "reason": "insufficient_stress_samples",
+            "confidence": "low",
+            "truncated": False,
+            "intervals": [],
+        }
+    if series_truncated and not samples_utc:
+        return {
+            "status": interpret.STATUS_INSUFFICIENT,
+            "date": day.isoformat(),
+            "timezone": str(tz),
+            "reason": "stress_timeseries_truncated",
+            "confidence": "low",
+            "coverage": 0.0,
+            "truncated": True,
+            "intervals": [],
+        }
 
     day_level: dict[str, Any] | None = None
     coverage: float | None = None
@@ -993,6 +1068,7 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
                     context.get("reason", "no_stress_timeseries_and_no_daily_proxy")
                 ),
                 "confidence": "low",
+                "truncated": False,
                 "intervals": [],
             }
         intervals = timeline.proxy_sections(day, tz, float(context["value"]))
@@ -1051,7 +1127,7 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
         )
         for interval in intervals
     ]
-    return {
+    response = {
         "status": interpret.STATUS_OK,
         "date": day.isoformat(),
         "timezone": str(tz),
@@ -1059,8 +1135,14 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
         "coverage": coverage,
         "confidence": confidence,
         "day_level_stress": day_level,
+        "truncated": series_truncated,
         "intervals": interval_payload,
     }
+    if series_truncated:
+        response["status"] = interpret.STATUS_INSUFFICIENT
+        response["reason"] = "stress_timeseries_truncated"
+        response["confidence"] = "low"
+    return response
 
 
 # Metric registry for compare_impact: how each metric is measured around an
@@ -1235,13 +1317,16 @@ async def _intraday_stress_deltas(
     for occurrence in occurrences:
         pre_start = occurrence.start - span
         post_end = occurrence.end + span
-        series_rows = await client.collect_timeseries(
+        series_rows, truncated = await client.collect_timeseries_tracked(
             user_id,
             pre_start.isoformat(),
             post_end.isoformat(),
             [STRESS_SERIES_TYPE],
             max_pages=4,
         )
+        if truncated:
+            skipped += 1
+            continue
         samples = _stress_samples(series_rows)
         before = impact.window_mean(
             samples, pre_start, occurrence.start, min_samples=IMPACT_MIN_SIDE_SAMPLES
@@ -1317,13 +1402,16 @@ async def compare_impact(
     occurrences.extend(workout_occurrences)
     occurrences.sort(key=lambda occurrence: occurrence.start)
     total_matched = len(occurrences)
-    truncated = total_matched > IMPACT_MAX_OCCURRENCES
-    if truncated:  # keep the most recent occurrences
-        occurrences = occurrences[-IMPACT_MAX_OCCURRENCES:]
 
     spec = dict(_IMPACT_METRICS[metric])
     if spec["kind"] == "nightly":
         occurrences_by_day = impact.dedupe_by_local_day(occurrences, tz)
+        truncated = len(occurrences_by_day) > IMPACT_MAX_OCCURRENCES
+        if truncated:
+            recent_days = sorted(occurrences_by_day)[-IMPACT_MAX_OCCURRENCES:]
+            occurrences_by_day = {
+                day: occurrences_by_day[day] for day in recent_days
+            }
         used = len(occurrences_by_day)
         daily, detail = await _nightly_daily_series(
             metric,
@@ -1336,6 +1424,9 @@ async def compare_impact(
         spec.update(detail)
         rows, skipped = impact.nightly_deltas(occurrences_by_day, daily)
     else:
+        truncated = total_matched > IMPACT_MAX_OCCURRENCES
+        if truncated:  # intraday metrics cap raw occurrences
+            occurrences = occurrences[-IMPACT_MAX_OCCURRENCES:]
         used = len(occurrences)
         rows, skipped = await _intraday_stress_deltas(client, user_id, occurrences, tz)
 

--- a/healthmes/mcp_server/timeline.py
+++ b/healthmes/mcp_server/timeline.py
@@ -37,7 +37,7 @@ Fixed, documented policy (so results are reproducible and hand-checkable):
 import statistics
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta, tzinfo
+from datetime import UTC, date, datetime, time, timedelta, tzinfo
 from typing import Any
 
 __all__ = [
@@ -92,7 +92,11 @@ class StressInterval:
 
     @property
     def duration_minutes(self) -> float:
-        return (self.end - self.start).total_seconds() / 60.0
+        return (_utc(self.end) - _utc(self.start)).total_seconds() / 60.0
+
+
+def _utc(value: datetime) -> datetime:
+    return value.astimezone(UTC)
 
 
 def stress_label(value: float) -> str:
@@ -105,9 +109,9 @@ def stress_label(value: float) -> str:
 
 def _median_step_minutes(points: Sequence[tuple[datetime, float]]) -> float:
     gaps = [
-        (points[i + 1][0] - points[i][0]).total_seconds() / 60.0
+        (_utc(points[i + 1][0]) - _utc(points[i][0])).total_seconds() / 60.0
         for i in range(len(points) - 1)
-        if points[i + 1][0] > points[i][0]
+        if _utc(points[i + 1][0]) > _utc(points[i][0])
     ]
     if not gaps:
         return FALLBACK_STEP_MINUTES
@@ -126,12 +130,12 @@ class _Run:
 
     @property
     def duration_minutes(self) -> float:
-        return (self.end - self.start).total_seconds() / 60.0
+        return (_utc(self.end) - _utc(self.start)).total_seconds() / 60.0
 
     def absorb(self, other: "_Run") -> None:
         self.points.extend(other.points)
-        self.points.sort(key=lambda item: item[0])
-        self.end = max(self.end, other.end)
+        self.points.sort(key=lambda item: _utc(item[0]))
+        self.end = max((self.end, other.end), key=_utc)
 
 
 def build_stress_intervals(
@@ -147,9 +151,12 @@ def build_stress_intervals(
     though the vendor ingest already filters them.
     """
     points = sorted(
-        (ts, float(value))
-        for ts, value in samples
-        if value is not None and float(value) >= 0.0
+        (
+            (ts, float(value))
+            for ts, value in samples
+            if value is not None and float(value) >= 0.0
+        ),
+        key=lambda item: _utc(item[0]),
     )
     if not points:
         return []
@@ -161,11 +168,16 @@ def build_stress_intervals(
     runs: list[_Run] = []
     for ts, value in points:
         label = stress_label(value)
-        if runs and runs[-1].label == label and ts - runs[-1].points[-1][0] <= max_gap:
+        end = (_utc(ts) + step).astimezone(ts.tzinfo)
+        if (
+            runs
+            and runs[-1].label == label
+            and _utc(ts) - _utc(runs[-1].points[-1][0]) <= max_gap
+        ):
             runs[-1].points.append((ts, value))
-            runs[-1].end = ts + step
+            runs[-1].end = end
         else:
-            runs.append(_Run(label=label, points=[(ts, value)], end=ts + step))
+            runs.append(_Run(label=label, points=[(ts, value)], end=end))
 
     # 2. smoothing: absorb short touching runs into their predecessor, then
     #    merge touching same-band neighbors created by the absorption.
@@ -173,7 +185,7 @@ def build_stress_intervals(
     for run in runs:
         if merged:
             prev = merged[-1]
-            touching = run.start <= prev.end
+            touching = _utc(run.start) <= _utc(prev.end)
             if touching and run.label == prev.label:
                 prev.absorb(run)
                 continue
@@ -185,7 +197,7 @@ def build_stress_intervals(
     if (
         len(merged) >= 2
         and merged[0].duration_minutes < min_run_minutes
-        and merged[1].start <= merged[0].end
+        and _utc(merged[1].start) <= _utc(merged[0].end)
     ):
         merged[1].absorb(merged[0])
         merged = merged[1:]
@@ -256,14 +268,16 @@ def attach_context(
     interval (a bucket is ``[bucket_start, bucket_start + bucket_minutes)``).
     """
     context: list[str] = []
+    window_start_utc = _utc(window_start)
+    window_end_utc = _utc(window_end)
 
     overlapping = sorted(
         (
             (start, end, summary)
             for start, end, summary in events
-            if start < window_end and end > window_start
+            if _utc(start) < window_end_utc and _utc(end) > window_start_utc
         ),
-        key=lambda item: (item[0], item[2] or ""),
+        key=lambda item: (_utc(item[0]), item[2] or ""),
     )
     for _start, _end, summary in overlapping[:max_events]:
         title = (summary or "").strip() or "(untitled)"
@@ -272,8 +286,11 @@ def attach_context(
     bucket_span = timedelta(minutes=bucket_minutes)
     minutes_by_category: dict[str, float] = {}
     for bucket_start, category, foreground_seconds in usage:
-        bucket_end = bucket_start + bucket_span
-        overlap = min(bucket_end, window_end) - max(bucket_start, window_start)
+        bucket_start_utc = _utc(bucket_start)
+        bucket_end_utc = bucket_start_utc + bucket_span
+        overlap = min(bucket_end_utc, window_end_utc) - max(
+            bucket_start_utc, window_start_utc
+        )
         overlap_seconds = overlap.total_seconds()
         if overlap_seconds <= 0:
             continue

--- a/tests/api/test_landing.py
+++ b/tests/api/test_landing.py
@@ -1,0 +1,80 @@
+"""Landing shell (GET /) carries no credentials.
+
+The static landing must never put a token on its links. The viewer token is an
+HMAC of the API token that a browser client cannot derive, so propagating a
+``?token=`` from the visitor's own URL onto same-origin links (what the old
+inline script did) could only leak a pasted *full* bearer token onto the /v1
+links. These tests pin that the served markup holds no token-propagation hook
+and that no credential — raw API token or derived viewer token — ever appears
+in a link. The client/settings fixtures come from tests/api/conftest.py.
+"""
+
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from healthmes.api.auth import viewer_token
+from healthmes.app import create_app
+
+_HREF = re.compile(r'href="([^"]*)"')
+
+
+def _hrefs(html: str) -> list[str]:
+    return _HREF.findall(html)
+
+
+@pytest.fixture
+def client(app):
+    """Landing served by the shared api-test app (tokenless settings)."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_landing_returns_200_with_surface_links(client) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    hrefs = _hrefs(response.text)
+    # Real-page sanity: the surface cards are present to assert against.
+    assert "/decisions" in hrefs
+    assert "/v1/briefing/glance" in hrefs
+
+
+def test_landing_links_carry_no_token_and_no_propagation_hook(client) -> None:
+    html = client.get("/").text
+    # No link carries a token, and the token-propagation hook/script is gone.
+    for href in _hrefs(html):
+        assert "token=" not in href
+    assert "data-token-link" not in html
+    assert "token=" not in html  # nothing anywhere hands a link a token
+    # The /v1 link — the leak vector — carries no query credential at all.
+    v1_hrefs = [href for href in _hrefs(html) if href.startswith("/v1/")]
+    assert v1_hrefs  # it is present...
+    for href in v1_hrefs:
+        assert "?" not in href and "token" not in href
+
+
+def test_landing_does_not_rewrite_links_from_visitor_token(client) -> None:
+    """A ?token= in the visitor's own URL must NOT be copied onto the links
+    (the inline rewrite script is deleted) nor echoed anywhere in the page."""
+    leaked = "leaked-full-bearer-token-value"
+    response = client.get(f"/?token={leaked}")
+    assert response.status_code == 200
+    for href in _hrefs(response.text):
+        assert "token=" not in href
+    assert leaked not in response.text
+
+
+def test_landing_never_echoes_the_configured_api_token(settings) -> None:
+    """Even with a real API token configured, GET / (an OPEN_PATH) renders
+    neither the raw API token nor its derived viewer token."""
+    secret = "super-secret-raw-api-token-value"
+    tokened = settings.model_copy(update={"api_token": SecretStr(secret)})
+    with TestClient(create_app(tokened)) as test_client:
+        response = test_client.get("/")
+    assert response.status_code == 200
+    assert secret not in response.text
+    assert viewer_token(secret) not in response.text
+    for href in _hrefs(response.text):
+        assert "token=" not in href

--- a/tests/backup/test_remote_vault.py
+++ b/tests/backup/test_remote_vault.py
@@ -116,6 +116,28 @@ class TestSeamGuard:
             provider.push(stray)
         assert provider._s3 is None  # client was never even constructed
 
+    def test_refuses_plaintext_with_forged_age_magic_prefix(self, vault, s3, tmp_path):
+        """A plaintext file forged to *start* with the age v1 magic line — but
+        with no recipient stanza and no ``--- <MAC>`` terminator — is refused.
+
+        This is the exfiltration the prefix-only check missed: prepend the magic
+        to a raw database and it would have sailed through."""
+        forged = tmp_path / "healthmes-backup-20260101T000000Z.tar.gz.age"
+        forged.write_bytes(b"age-encryption.org/v1\nSQLite format 3\x00 plaintext health data")
+        with pytest.raises(BackupError, match="not an age-encrypted envelope"):
+            vault.push(forged)
+        assert vault_keys(s3) == []
+
+    def test_accepts_a_real_age_encrypted_snapshot(self, vault, s3, local_provider):
+        """A genuine pyrage-encrypted snapshot passes the structural guard and
+        is uploaded byte-identically."""
+        local_info = local_provider.export_snapshot()
+        remote_info = vault.push(local_info.path)
+        assert remote_info.name == local_info.name
+        assert vault_keys(s3) == [f"{PREFIX}/{local_info.name}"]
+        obj = s3.get_object(Bucket=BUCKET, Key=f"{PREFIX}/{local_info.name}")
+        assert obj["Body"].read() == local_info.path.read_bytes()
+
 
 # ---------------------------------------------------------------------------
 # Push / download / list against the fake vault

--- a/tests/calendars/test_google.py
+++ b/tests/calendars/test_google.py
@@ -8,6 +8,7 @@ import pytest
 
 from healthmes.calendars.base import (
     CalendarAuthError,
+    CalendarConflictError,
     EventNotFoundError,
     OwnershipError,
 )
@@ -30,11 +31,15 @@ class FakeStatusError(Exception):
 
 
 class _FakeRequest:
+    """Mirrors googleapiclient ``HttpRequest``: a mutable ``headers`` dict that
+    the backend can set (``If-Match``) before ``execute``."""
+
     def __init__(self, fn) -> None:
         self._fn = fn
+        self.headers: dict[str, str] = {}
 
     def execute(self):
-        return self._fn()
+        return self._fn(self.headers)
 
 
 class _FakeEvents:
@@ -43,23 +48,27 @@ class _FakeEvents:
 
     def list(self, **params):
         self._service.list_calls.append(params)
-        return _FakeRequest(lambda: self._service.next_list_response())
+        return _FakeRequest(lambda headers: self._service.next_list_response())
 
     def get(self, calendarId, eventId):  # noqa: N803 - google client casing
         self._service.get_calls.append((calendarId, eventId))
-        return _FakeRequest(lambda: self._service.get_event(eventId))
+        return _FakeRequest(lambda headers: self._service.get_event(eventId))
 
     def insert(self, calendarId, body):  # noqa: N803
         self._service.insert_calls.append((calendarId, body))
-        return _FakeRequest(lambda: self._service.insert_event(body))
+        return _FakeRequest(lambda headers: self._service.insert_event(body))
 
     def patch(self, calendarId, eventId, body):  # noqa: N803
         self._service.patch_calls.append((calendarId, eventId, body))
-        return _FakeRequest(lambda: self._service.patch_event(eventId, body))
+        return _FakeRequest(
+            lambda headers: self._service.patch_event(eventId, body, headers)
+        )
 
     def delete(self, calendarId, eventId):  # noqa: N803
         self._service.delete_calls.append((calendarId, eventId))
-        return _FakeRequest(lambda: self._service.delete_event(eventId))
+        return _FakeRequest(
+            lambda headers: self._service.delete_event(eventId, headers)
+        )
 
 
 class FakeGoogleService:
@@ -73,6 +82,10 @@ class FakeGoogleService:
         self.insert_calls: list[tuple] = []
         self.patch_calls: list[tuple] = []
         self.delete_calls: list[tuple] = []
+        self.write_headers: list[dict] = []  # headers seen by patch/delete execs
+        #: When True the next conditional write 412s (simulate a concurrent
+        #: remote edit invalidating the etag we read).
+        self.fail_precondition = False
 
     def events(self) -> _FakeEvents:
         return _FakeEvents(self)
@@ -94,17 +107,32 @@ class FakeGoogleService:
         self.stored_events[event_id] = stored
         return stored
 
-    def patch_event(self, event_id: str, body: dict) -> dict:
+    def patch_event(self, event_id: str, body: dict, headers: dict) -> dict:
+        self.write_headers.append(dict(headers))
+        self._enforce_precondition(event_id, headers)
         stored = dict(self.stored_events[event_id])
         stored.update(body)
         stored["etag"] = '"patched"'
         self.stored_events[event_id] = stored
         return stored
 
-    def delete_event(self, event_id: str) -> None:
+    def delete_event(self, event_id: str, headers: dict) -> None:
+        self.write_headers.append(dict(headers))
+        self._enforce_precondition(event_id, headers)
         if event_id not in self.stored_events:
             raise FakeStatusError(404)
         del self.stored_events[event_id]
+
+    def _enforce_precondition(self, event_id: str, headers: dict) -> None:
+        """Reject a conditional write whose ``If-Match`` no longer matches."""
+        if_match = headers.get("If-Match")
+        if if_match is None:
+            return
+        if self.fail_precondition:
+            raise FakeStatusError(412)
+        current = self.stored_events.get(event_id)
+        if current is not None and current.get("etag") != if_match:
+            raise FakeStatusError(412)
 
 
 @pytest.fixture
@@ -292,6 +320,8 @@ class TestUpdateAndDelete:
         assert event_id == "mine"
         assert set(body) == {"start", "end"}
         assert updated.start_at == datetime(2026, 7, 10, 14, 0, tzinfo=UTC)
+        # The patch is guarded by the etag read via GET (optimistic concurrency).
+        assert service.write_headers[-1]["If-Match"] == '"e1"'
 
     def test_update_refuses_untagged_event(self, backend, service) -> None:
         service.stored_events["theirs"] = api_event("theirs", agent=False)
@@ -317,12 +347,40 @@ class TestUpdateAndDelete:
         backend.delete_event("mine")
         assert service.delete_calls == [("primary", "mine")]
         assert "mine" not in service.stored_events
+        # The delete is guarded by the etag read via GET (optimistic concurrency).
+        assert service.write_headers[-1]["If-Match"] == '"e1"'
 
     def test_delete_refuses_untagged_event(self, backend, service) -> None:
         service.stored_events["theirs"] = api_event("theirs", agent=False)
         with pytest.raises(OwnershipError):
             backend.delete_event("theirs")
         assert service.delete_calls == []
+
+    def test_update_conflict_412_raises_and_leaves_event_unmutated(
+        self, backend, service
+    ) -> None:
+        # F3: the event changed remotely between our GET and our PATCH. The
+        # If-Match precondition must make the write 412, not silently overwrite.
+        service.stored_events["mine"] = api_event("mine", agent=True)
+        original = dict(service.stored_events["mine"])
+        service.fail_precondition = True
+        with pytest.raises(CalendarConflictError):
+            backend.update_event(
+                "mine",
+                start_at=datetime(2026, 7, 10, 14, 0, tzinfo=UTC),
+                end_at=datetime(2026, 7, 10, 15, 0, tzinfo=UTC),
+            )
+        assert service.write_headers[-1]["If-Match"] == '"e1"'  # precondition sent
+        assert service.stored_events["mine"] == original  # never overwritten
+
+    def test_delete_conflict_412_raises_and_leaves_event(self, backend, service) -> None:
+        service.stored_events["mine"] = api_event("mine", agent=True)
+        original = dict(service.stored_events["mine"])
+        service.fail_precondition = True
+        with pytest.raises(CalendarConflictError):
+            backend.delete_event("mine")
+        assert service.write_headers[-1]["If-Match"] == '"e1"'  # precondition sent
+        assert service.stored_events["mine"] == original  # never deleted
 
 
 # --- OAuth helpers (offline: file handling only) -------------------------------

--- a/tests/calendars/test_jobs.py
+++ b/tests/calendars/test_jobs.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 import pytest
 from sqlalchemy import select
 
+from healthmes.calendars.base import EventDraft
 from healthmes.calendars.jobs import (
     build_calendar_job,
     build_calendar_jobs,
@@ -19,7 +20,7 @@ from healthmes.calendars.jobs import (
     push_accepted_proposals,
     write_source,
 )
-from healthmes.calendars.state import InMemorySyncStateStore
+from healthmes.calendars.state import InMemoryPendingDiffStore, InMemorySyncStateStore
 from healthmes.calendars.sync import CalendarMirrorService
 from healthmes.store import (
     CalendarEventMirror,
@@ -89,6 +90,34 @@ class TestJobRun:
         rows = session.scalars(select(CalendarEventMirror)).all()
         assert [row.external_id for row in rows] == ["meet-1"]
         assert fake_backend.received_sync_states == [None]
+
+    def test_job_returns_deletion_diff(
+        self, settings, session_factory, session, fake_backend, make_event
+    ) -> None:
+        # F4: the poll job must RETURN the SyncDiff so the schedule_changed
+        # trigger can consume deletions (which vanish from the mirror and so
+        # cannot be re-derived from row updated_at).
+        job = build_calendar_job(
+            settings,
+            fake_backend.source,
+            is_write_backend=False,
+            backend_factory=lambda: fake_backend,
+            session_factory=session_factory,
+            state_store=InMemorySyncStateStore(),
+            pending_store=InMemoryPendingDiffStore(),
+        )
+        fake_backend.queue_changes([make_event("meet-1")], {"sync_token": "tok-1"})
+        fake_backend.queue_changes(
+            [make_event("meet-1", deleted=True, summary=None, etag=None)],
+            {"sync_token": "tok-2"},
+        )
+
+        bootstrap_diff = job()  # silent adoption, but still a SyncDiff
+        assert bootstrap_diff is not None and not bootstrap_diff.has_changes
+
+        deletion_diff = job()
+        assert deletion_diff is not None
+        assert [change.external_id for change in deletion_diff.deleted] == ["meet-1"]
 
     def test_write_backend_pushes_accepted_proposals(
         self, settings, session_factory, session, fake_backend
@@ -213,6 +242,49 @@ class TestJobRun:
         session.expire_all()
         proposal = session.scalars(select(ScheduleProposal)).one()
         assert proposal.status is ProposalStatus.ACCEPTED
+
+    def test_crash_after_remote_create_does_not_duplicate_event(
+        self, session, fake_backend
+    ) -> None:
+        # F8: a prior poll created the remote block + mirror row but crashed
+        # before flipping the proposal to pushed. The retry must reuse the
+        # existing block, not create a second remote event.
+        task = Task(title="Write report")
+        session.add(task)
+        session.flush()
+        session.add(
+            ScheduleProposal(
+                task_id=task.id,
+                proposed_start=utc(2026, 7, 10, 9, 0),
+                proposed_end=utc(2026, 7, 10, 11, 0),
+                status=ProposalStatus.ACCEPTED,
+            )
+        )
+        session.commit()
+
+        service = CalendarMirrorService(session, [fake_backend], InMemorySyncStateStore())
+        # Simulate the interrupted prior poll: the block already exists remotely
+        # and in the mirror, but the proposal is still ACCEPTED.
+        service.create_agent_event(
+            fake_backend.source,
+            EventDraft(
+                summary="Write report",
+                start_at=utc(2026, 7, 10, 9, 0),
+                end_at=utc(2026, 7, 10, 11, 0),
+                agent_task_id=task.id,
+            ),
+        )
+        assert len(fake_backend.created_drafts) == 1
+
+        pushed = push_accepted_proposals(service, session, fake_backend.source)
+
+        assert pushed == 1
+        assert len(fake_backend.created_drafts) == 1  # NO second remote create
+        session.expire_all()
+        assert len(session.scalars(select(CalendarEventMirror)).all()) == 1
+        assert session.scalars(select(ScheduleProposal)).one().status is (
+            ProposalStatus.PUSHED
+        )
 
 
 @pytest.mark.parametrize("source", [CalendarSource.GOOGLE, CalendarSource.CALDAV])

--- a/tests/calendars/test_state.py
+++ b/tests/calendars/test_state.py
@@ -1,8 +1,11 @@
-"""Sync-state store tests: round-trips, isolation per source, corruption safety."""
+"""Sync-state / journal store tests: round-trips, per-source isolation, corruption."""
 
 from healthmes.calendars.state import (
+    FilePendingDiffStore,
     FileSyncStateStore,
+    InMemoryPendingDiffStore,
     InMemorySyncStateStore,
+    PendingDiffStore,
     SyncStateStore,
 )
 from healthmes.store.enums import CalendarSource
@@ -34,16 +37,16 @@ class TestInMemorySyncStateStore:
 
 
 class TestFileSyncStateStore:
-    def test_missing_file_means_never_synced(self, tmp_path) -> None:
-        store = FileSyncStateStore(tmp_path / "sync_state.json")
+    def test_missing_dir_means_never_synced(self, tmp_path) -> None:
+        store = FileSyncStateStore(tmp_path / "calendars")
         assert store.load(CalendarSource.GOOGLE) is None
 
     def test_round_trip_persists_across_instances(self, tmp_path) -> None:
-        path = tmp_path / "nested" / "sync_state.json"
-        FileSyncStateStore(path).save(
+        directory = tmp_path / "nested" / "calendars"
+        FileSyncStateStore(directory).save(
             CalendarSource.GOOGLE, {"sync_token": "t1", "known_ids": {"a": "e1"}}
         )
-        reopened = FileSyncStateStore(path)
+        reopened = FileSyncStateStore(directory)
         assert reopened.load(CalendarSource.GOOGLE) == {
             "sync_token": "t1",
             "known_ids": {"a": "e1"},
@@ -51,8 +54,7 @@ class TestFileSyncStateStore:
         assert reopened.load(CalendarSource.CALDAV) is None
 
     def test_save_replaces_only_that_source(self, tmp_path) -> None:
-        path = tmp_path / "sync_state.json"
-        store = FileSyncStateStore(path)
+        store = FileSyncStateStore(tmp_path)
         store.save(CalendarSource.GOOGLE, {"sync_token": "t1"})
         store.save(CalendarSource.CALDAV, {"ctag": "c1"})
         store.save(CalendarSource.GOOGLE, {"sync_token": "t2"})
@@ -60,22 +62,85 @@ class TestFileSyncStateStore:
         assert store.load(CalendarSource.CALDAV) == {"ctag": "c1"}
 
     def test_corrupted_file_degrades_to_full_resync(self, tmp_path) -> None:
-        path = tmp_path / "sync_state.json"
-        path.write_text("{not json", encoding="utf-8")
-        store = FileSyncStateStore(path)
+        store = FileSyncStateStore(tmp_path)
+        target = store.path_for(CalendarSource.GOOGLE)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{not json", encoding="utf-8")
         assert store.load(CalendarSource.GOOGLE) is None
         store.save(CalendarSource.GOOGLE, {"sync_token": "t1"})  # recovers by rewriting
         assert store.load(CalendarSource.GOOGLE) == {"sync_token": "t1"}
 
     def test_no_temp_file_left_behind(self, tmp_path) -> None:
-        path = tmp_path / "sync_state.json"
-        FileSyncStateStore(path).save(CalendarSource.GOOGLE, {"sync_token": "t1"})
-        assert [p.name for p in tmp_path.iterdir()] == ["sync_state.json"]
+        FileSyncStateStore(tmp_path).save(CalendarSource.GOOGLE, {"sync_token": "t1"})
+        assert [p.name for p in tmp_path.iterdir()] == ["sync_state.google.json"]
+
+    def test_concurrent_sources_do_not_clobber_each_other(self, tmp_path) -> None:
+        # F7: per-source files mean writing one source never rewrites (and so
+        # can never lose) another source's state — the failure mode of a single
+        # shared read-modify-write document under overlapping polls.
+        store = FileSyncStateStore(tmp_path)
+        store.save(CalendarSource.GOOGLE, {"sync_token": "g1"})
+        google_file = store.path_for(CalendarSource.GOOGLE)
+        google_bytes = google_file.read_bytes()
+
+        store.save(CalendarSource.CALDAV, {"ctag": "c1"})
+
+        assert google_file.read_bytes() == google_bytes  # untouched by caldav write
+        assert store.load(CalendarSource.GOOGLE) == {"sync_token": "g1"}
+        assert store.load(CalendarSource.CALDAV) == {"ctag": "c1"}
+        assert google_file != store.path_for(CalendarSource.CALDAV)
+
+    def test_clear_one_source_leaves_others(self, tmp_path) -> None:
+        store = FileSyncStateStore(tmp_path)
+        store.save(CalendarSource.GOOGLE, {"sync_token": "t1"})
+        store.save(CalendarSource.CALDAV, {"ctag": "c1"})
+        store.clear(CalendarSource.GOOGLE)
+        assert store.load(CalendarSource.GOOGLE) is None
+        assert store.load(CalendarSource.CALDAV) == {"ctag": "c1"}
 
     def test_for_data_dir_layout(self, tmp_path) -> None:
         store = FileSyncStateStore.for_data_dir(tmp_path)
-        assert store.path == tmp_path / "calendars" / "sync_state.json"
+        assert store.directory == tmp_path / "calendars"
+        assert store.path_for(CalendarSource.GOOGLE) == (
+            tmp_path / "calendars" / "sync_state.google.json"
+        )
 
     def test_satisfies_protocol(self, tmp_path) -> None:
-        assert isinstance(FileSyncStateStore(tmp_path / "s.json"), SyncStateStore)
+        assert isinstance(FileSyncStateStore(tmp_path), SyncStateStore)
         assert isinstance(InMemorySyncStateStore(), SyncStateStore)
+
+
+class TestPendingDiffStore:
+    def test_file_round_trip_and_clear(self, tmp_path) -> None:
+        store = FilePendingDiffStore(tmp_path)
+        assert store.load(CalendarSource.GOOGLE) is None
+        payload = {
+            "created": [],
+            "moved": [],
+            "deleted": [{"external_id": "gone-1", "kind": "deleted"}],
+            "agent_modified": [],
+        }
+        store.save(CalendarSource.GOOGLE, payload)
+        assert store.load(CalendarSource.GOOGLE) == payload
+        store.clear(CalendarSource.GOOGLE)
+        assert store.load(CalendarSource.GOOGLE) is None
+
+    def test_file_per_source_isolation(self, tmp_path) -> None:
+        store = FilePendingDiffStore(tmp_path)
+        store.save(CalendarSource.GOOGLE, {"deleted": ["g"]})
+        store.save(CalendarSource.CALDAV, {"deleted": ["c"]})
+        assert store.load(CalendarSource.GOOGLE) == {"deleted": ["g"]}
+        assert store.load(CalendarSource.CALDAV) == {"deleted": ["c"]}
+        assert store.path_for(CalendarSource.GOOGLE) != store.path_for(CalendarSource.CALDAV)
+
+    def test_in_memory_round_trip_is_copied(self, tmp_path) -> None:
+        store = InMemoryPendingDiffStore()
+        store.save(CalendarSource.GOOGLE, {"deleted": [{"external_id": "x"}]})
+        loaded = store.load(CalendarSource.GOOGLE)
+        assert loaded == {"deleted": [{"external_id": "x"}]}
+        loaded["deleted"].append("mutation")
+        assert store.load(CalendarSource.GOOGLE) == {"deleted": [{"external_id": "x"}]}
+
+    def test_satisfies_protocol(self, tmp_path) -> None:
+        assert isinstance(FilePendingDiffStore(tmp_path), PendingDiffStore)
+        assert isinstance(InMemoryPendingDiffStore(), PendingDiffStore)

--- a/tests/calendars/test_sync.py
+++ b/tests/calendars/test_sync.py
@@ -13,7 +13,10 @@ from healthmes.calendars.base import (
     EventNotFoundError,
     OwnershipError,
 )
-from healthmes.calendars.state import InMemorySyncStateStore
+from healthmes.calendars.state import (
+    InMemoryPendingDiffStore,
+    InMemorySyncStateStore,
+)
 from healthmes.calendars.sync import CalendarMirrorService, ChangeKind
 from healthmes.store import CalendarEventMirror, CalendarSource, Task
 
@@ -51,10 +54,15 @@ class TestBootstrap:
     def test_first_sync_adopts_everything_silently(
         self, service, fake_backend, session, make_event
     ) -> None:
+        # A genuine agent event carries BOTH the tag and a task id that resolves
+        # to a local Task row — a bare tag is no longer trusted (see F1).
+        task = Task(title="My focus block")
+        session.add(task)
+        session.commit()
         fake_backend.queue_changes(
             [
                 make_event("meet-1"),
-                make_event("mine-1", is_agent_created=True),
+                make_event("mine-1", is_agent_created=True, agent_task_id=task.id),
             ],
             {"sync_token": "tok-1"},
         )
@@ -64,7 +72,8 @@ class TestBootstrap:
         mirrored = rows(session)
         assert set(mirrored) == {"meet-1", "mine-1"}
         assert not mirrored["meet-1"].is_agent_created
-        assert mirrored["mine-1"].is_agent_created  # tag adopted from the wire
+        assert mirrored["mine-1"].is_agent_created  # trusted tag adopted from wire
+        assert mirrored["mine-1"].agent_task_id == task.id
 
     def test_bootstrap_persists_sync_state(self, service, fake_backend, state_store) -> None:
         fake_backend.queue_changes([], {"sync_token": "tok-1"})
@@ -249,18 +258,43 @@ class TestUnchangedRedelivery:
 
 
 class TestAgentEventDiff:
-    def _create_agent_block(self, service, fake_backend) -> str:
-        row = service.create_agent_event(fake_backend.source, draft())
-        return row.external_id
+    def _create_agent_block(self, service, fake_backend, session) -> tuple[str, object]:
+        """Create a task-linked agent block and return (external_id, task_id).
+
+        Agent blocks must carry a resolvable task id to stay trusted across a
+        provider round-trip (a bare tag is no longer trusted — see F1); the push
+        path always supplies one.
+        """
+        task = Task(title="Deep work")
+        session.add(task)
+        session.commit()
+        row = service.create_agent_event(
+            fake_backend.source, draft(agent_task_id=task.id)
+        )
+        return row.external_id, task.id
+
+    def _still_live(self, make_event, external_id, task_id):
+        """The agent block as the provider still returns it during bootstrap
+        (F6 would tombstone a mirror row the full-resync set omits)."""
+        return make_event(
+            external_id,
+            summary="Deep work",
+            start=utc(2026, 7, 10, 9, 0),
+            end=utc(2026, 7, 10, 11, 0),
+            is_agent_created=True,
+            agent_task_id=task_id,
+        )
 
     def test_external_move_of_agent_event_lands_in_agent_modified(
         self, service, fake_backend, session, make_event
     ) -> None:
-        external_id = self._create_agent_block(service, fake_backend)
-        fake_backend.queue_changes([], {"sync_token": "tok-1"})
+        external_id, task_id = self._create_agent_block(service, fake_backend, session)
+        fake_backend.queue_changes(
+            [self._still_live(make_event, external_id, task_id)], {"sync_token": "tok-1"}
+        )
         service.sync_backend(fake_backend)  # establish sync state
 
-        # User drags the agent block in Google Calendar: times change.
+        # User drags the agent block in Google Calendar: times change, tag kept.
         fake_backend.queue_changes(
             [
                 make_event(
@@ -269,6 +303,7 @@ class TestAgentEventDiff:
                     start=utc(2026, 7, 10, 16, 0),
                     end=utc(2026, 7, 10, 18, 0),
                     is_agent_created=True,
+                    agent_task_id=task_id,
                     etag="etag-3",
                 )
             ],
@@ -290,8 +325,10 @@ class TestAgentEventDiff:
     def test_external_delete_of_agent_event_lands_in_agent_modified(
         self, service, fake_backend, session, make_event
     ) -> None:
-        external_id = self._create_agent_block(service, fake_backend)
-        fake_backend.queue_changes([], {"sync_token": "tok-1"})
+        external_id, task_id = self._create_agent_block(service, fake_backend, session)
+        fake_backend.queue_changes(
+            [self._still_live(make_event, external_id, task_id)], {"sync_token": "tok-1"}
+        )
         service.sync_backend(fake_backend)
 
         fake_backend.queue_changes(
@@ -309,17 +346,21 @@ class TestAgentEventDiff:
         self, service, fake_backend, session, make_event
     ) -> None:
         # State exists (not bootstrap) but the row is missing (e.g. restored
-        # DB): a tagged event appearing is re-adopted without alerting.
+        # DB): a trusted tagged event appearing is re-adopted without alerting.
+        task = Task(title="Recovered block")
+        session.add(task)
+        session.commit()
         fake_backend.queue_changes([], {"sync_token": "tok-1"})
         service.sync_backend(fake_backend)
         fake_backend.queue_changes(
-            [make_event("mine-recovered", is_agent_created=True)],
+            [make_event("mine-recovered", is_agent_created=True, agent_task_id=task.id)],
             {"sync_token": "tok-2"},
         )
         diff = service.sync_backend(fake_backend)
 
         assert not diff.has_changes
         assert rows(session)["mine-recovered"].is_agent_created
+        assert rows(session)["mine-recovered"].agent_task_id == task.id
 
 
 class TestOwnershipGuard:
@@ -405,6 +446,200 @@ class TestOwnershipGuard:
                 start_at=utc(2026, 7, 11, 10, 0),
                 end_at=utc(2026, 7, 11, 9, 0),
             )
+
+
+class TestForgedTagOwnership:
+    """F1/F2: the ownership tag is trusted only with a resolvable task id."""
+
+    def _seed(self, service, fake_backend, make_event) -> None:
+        # Bootstrap so subsequent syncs report changes (not silent adoption).
+        fake_backend.queue_changes([make_event("seed")], {"sync_token": "tok-0"})
+        service.sync_backend(fake_backend)
+
+    def test_forged_agent_tag_never_authorizes_writes(
+        self, service, fake_backend, session, make_event
+    ) -> None:
+        self._seed(service, fake_backend, make_event)
+        # An external event carries the tag but its task id is bogus (never a
+        # local Task) — a hand-crafted claim of agent ownership.
+        fake_backend.queue_changes(
+            [make_event("forged", is_agent_created=True, agent_task_id=uuid.uuid4())],
+            {"sync_token": "tok-1"},
+        )
+        diff = service.sync_backend(fake_backend)
+
+        # Treated as the genuine external creation it is, not adopted as agent.
+        assert [change.external_id for change in diff.created] == ["forged"]
+        assert diff.agent_modified == []
+        row = rows(session)["forged"]
+        assert not row.is_agent_created
+        assert row.agent_task_id is None
+
+        # The ownership guard refuses agent writes, and no backend call is made.
+        with pytest.raises(OwnershipError):
+            service.move_agent_event(
+                fake_backend.source,
+                "forged",
+                start_at=utc(2026, 7, 11, 9, 0),
+                end_at=utc(2026, 7, 11, 10, 0),
+            )
+        with pytest.raises(OwnershipError):
+            service.delete_agent_event(fake_backend.source, "forged")
+        assert fake_backend.update_calls == []
+        assert fake_backend.delete_calls == []
+
+    def test_bare_agent_tag_without_task_id_is_external(
+        self, service, fake_backend, session, make_event
+    ) -> None:
+        self._seed(service, fake_backend, make_event)
+        fake_backend.queue_changes(
+            [make_event("bare", is_agent_created=True)],  # tag, but no task id
+            {"sync_token": "tok-1"},
+        )
+        diff = service.sync_backend(fake_backend)
+
+        assert [change.external_id for change in diff.created] == ["bare"]
+        assert not rows(session)["bare"].is_agent_created
+
+    def test_tag_stripped_during_move_becomes_external(
+        self, service, fake_backend, session, make_event
+    ) -> None:
+        task = Task(title="Deep work")
+        session.add(task)
+        session.commit()
+        created = service.create_agent_event(
+            fake_backend.source, draft(agent_task_id=task.id)
+        )
+        external_id = created.external_id
+        fake_backend.queue_changes(
+            [
+                make_event(
+                    external_id,
+                    summary="Deep work",
+                    start=utc(2026, 7, 10, 9, 0),
+                    end=utc(2026, 7, 10, 11, 0),
+                    is_agent_created=True,
+                    agent_task_id=task.id,
+                )
+            ],
+            {"sync_token": "tok-1"},
+        )
+        service.sync_backend(fake_backend)  # establish state, block still agent-owned
+
+        # The user strips the healthmes tag AND drags the event: it is no longer
+        # agent-owned, so the move is an EXTERNAL change (diff.moved, not
+        # agent_modified), and the agent can no longer write to it.
+        fake_backend.queue_changes(
+            [
+                make_event(
+                    external_id,
+                    summary="Deep work",
+                    start=utc(2026, 7, 10, 16, 0),
+                    end=utc(2026, 7, 10, 18, 0),
+                    is_agent_created=False,  # tag stripped
+                    etag="etag-x",
+                )
+            ],
+            {"sync_token": "tok-2"},
+        )
+        diff = service.sync_backend(fake_backend)
+
+        assert diff.agent_modified == []
+        (change,) = diff.moved
+        assert change.kind is ChangeKind.MOVED
+        assert not change.is_agent_created
+        assert change.new_start_at == utc(2026, 7, 10, 16, 0)
+
+        updated = rows(session)[external_id]
+        assert not updated.is_agent_created  # flipped to external
+        assert updated.agent_task_id is None
+        with pytest.raises(OwnershipError):
+            service.delete_agent_event(fake_backend.source, external_id)
+        assert fake_backend.delete_calls == []
+
+
+class TestFullResyncReconcile:
+    """F6: a full resync tombstones mirror rows the provider no longer returns."""
+
+    def test_full_resync_reconciles_missing_provider_events(
+        self, service, fake_backend, session, state_store, make_event
+    ) -> None:
+        fake_backend.queue_changes(
+            [make_event("keep-1"), make_event("gone-1")], {"sync_token": "tok-1"}
+        )
+        service.sync_backend(fake_backend)
+        assert set(rows(session)) == {"keep-1", "gone-1"}
+
+        # Sync state is lost -> the next run is a full resync that returns only
+        # keep-1; gone-1 was deleted while we had no cursor to observe it.
+        state_store.clear(fake_backend.source)
+        fake_backend.queue_changes([make_event("keep-1")], {"sync_token": "tok-2"})
+        diff = service.sync_backend(fake_backend)
+
+        assert [change.external_id for change in diff.deleted] == ["gone-1"]
+        assert diff.created == diff.moved == diff.agent_modified == []
+        assert set(rows(session)) == {"keep-1"}
+
+    def test_true_first_sync_emits_no_tombstones(
+        self, service, fake_backend, session, make_event
+    ) -> None:
+        # An empty mirror at bootstrap must stay silent (no phantom deletions).
+        fake_backend.queue_changes([make_event("meet-1")], {"sync_token": "tok-1"})
+        diff = service.sync_backend(fake_backend)
+        assert not diff.has_changes
+        assert set(rows(session)) == {"meet-1"}
+
+
+class _FailingOnceStateStore:
+    """Wraps a store, raising on the Nth ``save`` to simulate a cursor-save crash."""
+
+    def __init__(self, inner: InMemorySyncStateStore, *, fail_on_call: int) -> None:
+        self._inner = inner
+        self._fail_on = fail_on_call
+        self._calls = 0
+
+    def load(self, source):
+        return self._inner.load(source)
+
+    def save(self, source, state) -> None:
+        self._calls += 1
+        if self._calls == self._fail_on:
+            raise RuntimeError("cursor save failed")
+        self._inner.save(source, state)
+
+
+class TestPendingDiffJournal:
+    """F5: a diff whose cursor save failed is replayed, not lost."""
+
+    def test_pending_diff_replays_after_cursor_save_failure(
+        self, session, fake_backend, make_event
+    ) -> None:
+        # Bootstrap save is call #1 (succeeds); the deletion run's cursor save
+        # is call #2 (fails) after the idempotent mirror delete already landed.
+        flaky = _FailingOnceStateStore(InMemorySyncStateStore(), fail_on_call=2)
+        pending = InMemoryPendingDiffStore()
+        service = CalendarMirrorService(session, [fake_backend], flaky, pending)
+
+        fake_backend.queue_changes([make_event("meet-1")], {"sync_token": "tok-1"})
+        service.sync_backend(fake_backend)
+        assert set(rows(session)) == {"meet-1"}
+
+        fake_backend.queue_changes(
+            [make_event("meet-1", deleted=True, summary=None, etag=None)],
+            {"sync_token": "tok-2"},
+        )
+        with pytest.raises(RuntimeError, match="cursor save failed"):
+            service.sync_backend(fake_backend)
+        # The delete committed (idempotent, cannot be re-derived) and the diff
+        # is journaled for replay.
+        assert rows(session) == {}
+        assert pending.load(fake_backend.source) is not None
+
+        # Next run: nothing new from the provider, but the journal replays the
+        # deletion so the trigger still learns of it; the journal then clears.
+        diff = service.sync_backend(fake_backend)
+        assert [change.external_id for change in diff.deleted] == ["meet-1"]
+        assert pending.load(fake_backend.source) is None
 
 
 class TestMultiBackend:

--- a/tests/engine/test_triggers.py
+++ b/tests/engine/test_triggers.py
@@ -110,6 +110,22 @@ class FakeAlertSender:
         return WebhookResult(ok=False, status_code=502, detail="gateway unavailable")
 
 
+class RaisingAlertSender:
+    """AlertSender double whose send() *raises* (transport blew up mid-send).
+
+    Distinct from ``FakeAlertSender(ok=False)``, which returns a clean
+    ``WebhookResult(ok=False)`` — a gateway that answered non-2xx.
+    """
+
+    def __init__(self, exc: Exception | None = None) -> None:
+        self.exc = exc if exc is not None else RuntimeError("webhook transport exploded")
+        self.calls = 0
+
+    def send(self, fire: TriggerFire, *, fired_at: datetime) -> WebhookResult:
+        self.calls += 1
+        raise self.exc
+
+
 class FakeHealthReader:
     """HealthReader double returning canned signals."""
 
@@ -286,6 +302,63 @@ def test_native_delivery_off_keeps_webhook_only_semantics(settings, session_fact
     assert [o.status for o in report.outcomes] == ["push_failed"]
     [event] = all_events(session_factory)
     assert event.alert_sent is False
+
+
+def test_sender_exception_native_off_does_not_burn_dedup(settings, session_factory) -> None:
+    """A sender that *raises* (not a clean non-2xx) must not burn the dedup key.
+
+    The trigger_event row is flushed before the push; when the send raises and
+    native delivery is off the alert is genuinely undelivered, so the row is
+    deleted (delete+flush, not expunge) — otherwise the burned key would
+    dedup-drop the retry forever."""
+    sender = RaisingAlertSender()
+    with freeze_time("2026-07-09 14:00:00"):
+        evaluator = make_evaluator(settings, session_factory, sender, rules=(fixed_rule,))
+        report = evaluator.evaluate_once()
+
+    assert [o.status for o in report.outcomes] == ["push_failed"]
+    assert sender.calls == 1
+    # Row removed → dedup key not recorded (an expunge would have left it).
+    assert all_events(session_factory) == []
+
+
+def test_sender_exception_recovers_on_next_sweep(settings, session_factory) -> None:
+    """After a raising sweep unwinds the row, the identical fire re-fires and is
+    delivered on the next sweep (same dedup key, never truly recorded)."""
+    raising = RaisingAlertSender()
+    working = FakeAlertSender()
+    with freeze_time("2026-07-09 14:00:00") as frozen:
+        failed = make_evaluator(
+            settings, session_factory, raising, rules=(fixed_rule,)
+        ).evaluate_once()
+        frozen.tick(timedelta(minutes=10))
+        recovered = make_evaluator(
+            settings, session_factory, working, rules=(fixed_rule,)
+        ).evaluate_once()
+
+    assert [o.status for o in failed.outcomes] == ["push_failed"]
+    assert [o.status for o in recovered.outcomes] == ["pushed"]
+    assert len(working.sent) == 1
+    [event] = all_events(session_factory)  # only the delivered row survives
+    assert event.dedup_key == "fixed_rule:occurrence-1"
+    assert event.alert_sent is True
+
+
+def test_sender_exception_native_on_delivers_natively(settings, session_factory) -> None:
+    """native on: a raising sender still surfaces the alert to companion apps —
+    the row is kept, marked delivered natively, webhook flagged as failed."""
+    native_settings = settings.model_copy(update={"native_alert_delivery": True})
+    sender = RaisingAlertSender()
+    with freeze_time("2026-07-09 14:00:00"):
+        evaluator = make_evaluator(native_settings, session_factory, sender, rules=(fixed_rule,))
+        report = evaluator.evaluate_once()
+
+    assert [o.status for o in report.outcomes] == ["pushed"]
+    [event] = all_events(session_factory)
+    assert event.alert_sent is True
+    assert event.payload["push"]["channel"] == "native"
+    assert event.payload["push"]["webhook_ok"] is False
+    assert "webhook_error" in event.payload["push"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp_server/test_interpret.py
+++ b/tests/mcp_server/test_interpret.py
@@ -172,3 +172,60 @@ class TestOverallConfidence:
     def test_all_insufficient_is_low(self):
         assert interpret.overall_confidence([{"status": "insufficient_data"}]) == "low"
         assert interpret.overall_confidence([]) == "low"
+
+
+class TestMetricBaselineStaleness:
+    """Defect 5: an optional max_stale_days ceiling on the 'current' reading.
+
+    Without the ceiling the latest value on/before as_of is treated as current
+    no matter how old; the readiness call site passes a ceiling so a stale HRV
+    is not reported as today's state. Other callers pass no ceiling and keep
+    the original behavior.
+    """
+
+    def test_stale_current_is_insufficient_only_when_gated(self):
+        # Latest reading is 7 days before as_of, with 5 prior history days.
+        daily = {days_ago(n): 50.0 for n in (7, 8, 9, 10, 11, 12)}
+        # Ungated (default): enough history -> ok (baseline behavior preserved).
+        assert interpret.metric_baseline(daily, D)["status"] == "ok"
+        # Gated at 3 days: the current reading is stale -> honest insufficient.
+        gated = interpret.metric_baseline(daily, D, max_stale_days=3)
+        assert gated["status"] == "insufficient_data"
+        assert gated["reason"] == "current_reading_stale_gt_3_days"
+        assert gated["stale_days"] == 7
+        assert gated["current"] == {"date": days_ago(7).isoformat(), "value": 50.0}
+
+    def test_freshness_gate_boundary(self):
+        fresh = {days_ago(n): 50.0 for n in (3, 4, 5, 6, 7, 8)}  # latest exactly 3d old
+        assert interpret.metric_baseline(fresh, D, max_stale_days=3)["status"] == "ok"
+        stale = {days_ago(n): 50.0 for n in (4, 5, 6, 7, 8, 9)}  # latest 4d old
+        result = interpret.metric_baseline(stale, D, max_stale_days=3)
+        assert result["status"] == "insufficient_data"
+        assert result["stale_days"] == 4
+
+
+class TestChooseStressSeries:
+    """Defect 6: pick ONE stress series by freshness near as_of, never mix."""
+
+    def test_fresh_garmin_wins(self):
+        series, which = interpret.choose_stress_series({D: 60.0}, {D: 40.0}, D)
+        assert which == "garmin"
+        assert series == {D: 60.0}
+
+    def test_stale_garmin_yields_to_fresh_proxy(self):
+        # Garmin reading is 60 days old; the proxy is today -> proxy must win
+        # (a stale Garmin reading must NOT suppress a fresh proxy).
+        series, which = interpret.choose_stress_series({days_ago(60): 40.0}, {D: 35.0}, D)
+        assert which == "proxy"
+        assert series == {D: 35.0}
+
+    def test_both_empty_is_none(self):
+        assert interpret.choose_stress_series({}, {}, D) == ({}, "none")
+
+    def test_neither_fresh_prefers_most_recent_then_garmin_on_tie(self):
+        newer_g = interpret.choose_stress_series({days_ago(5): 1.0}, {days_ago(10): 2.0}, D)
+        assert newer_g[1] == "garmin"
+        newer_p = interpret.choose_stress_series({days_ago(10): 1.0}, {days_ago(5): 2.0}, D)
+        assert newer_p[1] == "proxy"
+        tie = interpret.choose_stress_series({days_ago(5): 1.0}, {days_ago(5): 2.0}, D)
+        assert tie[1] == "garmin"

--- a/tests/mcp_server/test_ow_client.py
+++ b/tests/mcp_server/test_ow_client.py
@@ -275,3 +275,63 @@ class TestResolveSingleUserId:
                 return {"items": [{"id": "sync-user"}], "total": 1}
 
         assert await resolve_single_user_id(SyncFake(), settings) == "sync-user"
+
+
+class TestPaginationTruncationTracked:
+    """Defect 8: the collectors must surface a truncated flag when the page cap
+    stops a fetch with more data available (offset and cursor variants)."""
+
+    async def test_collect_health_scores_tracked_flags_offset_truncation(
+        self, fake_ow, ow_client, ow_user_id
+    ):
+        for minute in range(11):
+            fake_ow.add_score("stress", "garmin", f"2026-07-08T08:{minute:02d}:00Z", 30 + minute)
+        fake_ow.max_page_size = 1  # 10-page cap hit with an 11th row still available
+        rows, truncated = await ow_client.collect_health_scores_tracked(
+            ow_user_id, start_date="2026-07-08", end_date="2026-07-09"
+        )
+        assert len(rows) == 10
+        assert truncated is True
+        fake_ow.max_page_size = None  # now it drains fully
+        rows, truncated = await ow_client.collect_health_scores_tracked(
+            ow_user_id, start_date="2026-07-08", end_date="2026-07-09"
+        )
+        assert len(rows) == 11
+        assert truncated is False
+
+    async def test_collect_sleep_summaries_tracked_flags_cursor_truncation(
+        self, ow_user_id, ow_api_key
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            cursor = request.url.params.get("cursor")
+            n = int(cursor) if cursor else 0
+            return httpx.Response(
+                200,
+                json={
+                    "data": [{"date": f"2026-07-{n + 1:02d}"}],
+                    "pagination": {"next_cursor": str(n + 1)},  # never terminates
+                },
+            )
+
+        client = OWClient(
+            base_url="http://open-wearables.test",
+            api_key=ow_api_key,
+            transport=httpx.MockTransport(handler),
+        )
+        rows, truncated = await client.collect_sleep_summaries_tracked(
+            ow_user_id, "2026-07-01", "2026-07-09", max_pages=3
+        )
+        assert len(rows) == 3  # capped
+        assert truncated is True  # a live cursor remained at the cap
+
+    async def test_plain_collectors_still_return_only_rows(
+        self, fake_ow, ow_client, ow_user_id
+    ):
+        # Backward-compat: the non-tracked API is unchanged for existing callers.
+        fake_ow.add_score("stress", "garmin", "2026-07-08T08:00:00Z", 30)
+        rows = await ow_client.collect_health_scores(
+            ow_user_id, start_date="2026-07-08", end_date="2026-07-09"
+        )
+        assert isinstance(rows, list)
+        assert rows[0]["value"] == 30
+

--- a/tests/mcp_server/test_timeline.py
+++ b/tests/mcp_server/test_timeline.py
@@ -6,6 +6,7 @@ accidental UTC assumptions in the arithmetic.
 """
 
 import datetime as dt
+import zoneinfo
 
 from healthmes.mcp_server import timeline
 
@@ -187,3 +188,49 @@ class TestCoverageAndConfidence:
             "n_samples": 1,
             "likely_context": ["event: Standup"],
         }
+
+
+class TestDstFoldMathInUtc:
+    """Defect 3: ordering / subtraction / end math must be done in UTC.
+
+    Across the America/New_York fall-back fold (2024-11-03) the wall clock runs
+    01:59 EDT -> 01:00 EST, so wall-clock addition of the sample step lands the
+    interval end an hour early (before its own last sample), inverting gap and
+    duration math. All arithmetic must go through UTC; local is display-only.
+    For the fixed-offset KST used elsewhere these conversions are the identity,
+    so the other timeline tests are unaffected.
+    """
+
+    NY = zoneinfo.ZoneInfo("America/New_York")
+
+    def _ny(self, hour: int, minute: int, value: float) -> tuple[dt.datetime, float]:
+        return (dt.datetime(2024, 11, 3, hour, minute, tzinfo=dt.UTC).astimezone(self.NY), value)
+
+    def test_end_and_duration_are_utc_correct_across_fold(self):
+        # UTC 05:45 / 06:00 / 06:15 -> NY 01:45 EDT / 01:00 EST / 01:15 EST:
+        # one contiguous rest run straddling the fold.
+        samples = [self._ny(5, 45, 20.0), self._ny(6, 0, 20.0), self._ny(6, 15, 20.0)]
+        intervals = timeline.build_stress_intervals(samples)
+        assert len(intervals) == 1
+        interval = intervals[0]
+        assert interval.label == "rest"
+        assert interval.n_samples == 3
+        # Start is the earliest sample; end is last sample + 15min step, in UTC.
+        assert interval.start.astimezone(dt.UTC) == dt.datetime(2024, 11, 3, 5, 45, tzinfo=dt.UTC)
+        assert interval.end.astimezone(dt.UTC) == dt.datetime(2024, 11, 3, 6, 30, tzinfo=dt.UTC)
+        # 05:45 -> 06:30 UTC = 45 min. Wall-clock addition would put the end at
+        # 01:30 EDT (05:30 UTC) -- before the last sample -- for a bogus span.
+        assert interval.duration_minutes == 45.0
+
+    def test_attach_context_overlap_is_utc_correct_across_fold(self):
+        # A 1h usage bucket starting 01:30 EDT (05:30 UTC) ends, in UTC, at 06:30
+        # UTC. Wall-clock addition would put its end at 02:30 "EDT" = 07:30 UTC,
+        # an hour late. The interval window is [05:30, 07:00) UTC (fully past the
+        # correct bucket end): correct overlap is the whole 60-min bucket
+        # (fraction 1.0 -> 60 min); the buggy end would over-credit 90 min.
+        bucket_start = dt.datetime(2024, 11, 3, 5, 30, tzinfo=dt.UTC).astimezone(self.NY)
+        window_end = dt.datetime(2024, 11, 3, 7, 0, tzinfo=dt.UTC).astimezone(self.NY)
+        usage = [(bucket_start, "social", 3600)]  # 60 min foreground in the 1h bucket
+        context = timeline.attach_context(bucket_start, window_end, [], usage)
+        assert context == ["apps: social (60 min)"]
+

--- a/tests/mcp_server/test_timezone.py
+++ b/tests/mcp_server/test_timezone.py
@@ -57,4 +57,55 @@ class TestLocalTimezoneResolution:
     def test_system_local_is_the_last_resort(self):
         server_module.set_settings(_StubSettings(None))  # type: ignore[arg-type]
         resolved = server_module._local_timezone()
-        assert isinstance(resolved, dt.tzinfo)
+        # Defect 2: never a captured fixed offset -- a real DST-aware IANA zone.
+        assert isinstance(resolved, zoneinfo.ZoneInfo)
+
+
+class TestSystemTimezone:
+    """Defect 2: the machine fallback resolves a real IANA zone, never a fixed
+    offset captured at process start (which would lose DST for off-season
+    queries)."""
+
+    def test_returns_real_iana_zone_not_fixed_offset(self):
+        from healthmes.config import system_timezone
+
+        tz = system_timezone()
+        assert isinstance(tz, zoneinfo.ZoneInfo)
+        assert not isinstance(tz, dt.timezone)  # never datetime.now().astimezone() offset
+
+    def test_falls_back_to_localtime_symlink_when_tzlocal_fails(self, monkeypatch):
+        import tzlocal
+
+        from healthmes.config import system_timezone
+
+        def _boom():
+            raise RuntimeError("tzlocal unavailable")
+
+        monkeypatch.setattr(tzlocal, "get_localzone", _boom)
+        tz = system_timezone()
+        # Resolved from the /etc/localtime symlink (Asia/Seoul on this machine);
+        # tolerate UTC on hosts without a zoneinfo symlink -- either way never a
+        # captured fixed local offset.
+        assert isinstance(tz, zoneinfo.ZoneInfo) or tz == dt.UTC
+
+    def test_falls_back_to_utc_when_everything_fails(self, monkeypatch):
+        import tzlocal
+
+        from healthmes import config
+        from healthmes.config import system_timezone
+
+        def _boom():
+            raise RuntimeError("tzlocal unavailable")
+
+        monkeypatch.setattr(tzlocal, "get_localzone", _boom)
+
+        class _BoomPath:
+            def __init__(self, *args):
+                pass
+
+            def resolve(self, *args, **kwargs):
+                raise OSError("no /etc/localtime")
+
+        monkeypatch.setattr(config, "Path", _BoomPath)
+        assert system_timezone() == dt.UTC
+

--- a/tests/mcp_server/test_tools_health.py
+++ b/tests/mcp_server/test_tools_health.py
@@ -66,6 +66,9 @@ class TestGetHealthScores:
     async def test_groups_and_interprets_by_category_provider(
         self, mcp_client, mcp_env, call_tool
     ):
+        # Three in-window days so the Defect-4 min-days-with-data gate is met
+        # (values chosen so mean/min/max are unchanged from the 2-day fixture).
+        mcp_env.add_score("stress", "garmin", "2026-07-06T12:00:00Z", 40, qualifier="low")
         mcp_env.add_score("stress", "garmin", "2026-07-07T12:00:00Z", 30, qualifier="calm")
         mcp_env.add_score("stress", "garmin", "2026-07-08T12:00:00Z", 50, qualifier="medium")
         # Out-of-window row that must not leak into the stats.
@@ -92,9 +95,9 @@ class TestGetHealthScores:
         assert stress["mean"] == 40.0
         assert stress["min"] == 30.0
         assert stress["max"] == 50.0
-        assert stress["n_samples"] == 2
-        assert stress["days_with_data"] == 2
-        assert stress["coverage"] == 0.29  # 2/7
+        assert stress["n_samples"] == 3
+        assert stress["days_with_data"] == 3
+        assert stress["coverage"] == 0.43  # 3/7
         assert stress["confidence"] == "low"
 
         # Internal resilience is normalized to the 0-100 score, raw CV kept.
@@ -258,3 +261,91 @@ class TestUserResolution:
         )
         with pytest.raises(ToolError, match="open-wearables API error"):
             await mcp_client.call_tool("get_health_scores", {"end_date": AS_OF})
+
+
+class TestReviewFindingFixes:
+    """Regression tests for the independent-review fixes on the health tools
+    (Defects 1, 4, 5, 6, 7, 8). Env is pinned to KST (UTC+9)."""
+
+    async def test_stress_grouped_by_local_day_not_utc(self, mcp_client, mcp_env, call_tool):
+        # Defect 1: 2026-07-14T22:00Z is 2026-07-15 07:00 in KST, so it must
+        # anchor to local day 07-15 (not UTC day 07-14). Before the fix it was
+        # grouped by UTC and reported as a day-stale reading on 07-14.
+        mcp_env.add_score("stress", "garmin", "2026-07-14T22:00:00Z", 62)
+        result = await call_tool(
+            mcp_client, "get_daily_readiness_context", {"date": "2026-07-15"}
+        )
+        stress = result["stress"]
+        assert stress["source"] == "garmin_stress"
+        assert stress["value"] == 62.0
+        assert stress["observed_on"] == "2026-07-15"  # local day, not 07-14
+        assert stress["stale_days"] == 0
+
+    async def test_health_scores_sparse_window_is_insufficient(
+        self, mcp_client, mcp_env, call_tool
+    ):
+        # Defect 4: two days of data in a 14d window is not a confident aggregate,
+        # but the partial per-group data is still returned honestly.
+        mcp_env.add_score("stress", "garmin", "2026-07-07T12:00:00Z", 30)
+        mcp_env.add_score("stress", "garmin", "2026-07-08T12:00:00Z", 50)
+        result = await call_tool(
+            mcp_client, "get_health_scores", {"range": "14d", "end_date": AS_OF}
+        )
+        assert result["status"] == "insufficient_data"  # best group has 2 < 3 days
+        assert result["truncated"] is False
+        assert result["scores"]["stress:garmin"]["days_with_data"] == 2  # data still shown
+
+    async def test_health_scores_truncation_is_insufficient(
+        self, mcp_client, mcp_env, call_tool
+    ):
+        # Defect 8: a truncated offset window must not be presented as "ok".
+        for day in (28, 29, 30):
+            mcp_env.add_score("stress", "garmin", f"2026-06-{day:02d}T12:00:00Z", 40)
+        for day in range(1, 9):  # 11 distinct in-window days in the 14d window
+            mcp_env.add_score("stress", "garmin", f"2026-07-{day:02d}T12:00:00Z", 40)
+        mcp_env.max_page_size = 1  # 10-page cap hit -> truncated
+        result = await call_tool(
+            mcp_client, "get_health_scores", {"range": "14d", "end_date": AS_OF}
+        )
+        assert result["truncated"] is True
+        assert result["status"] == "insufficient_data"
+
+    async def test_hrv_stale_current_is_insufficient(self, mcp_client, mcp_env, call_tool):
+        # Defect 5: the latest nocturnal HRV is 7 days before as_of -> not current.
+        for day in ("2026-06-26", "2026-06-27", "2026-06-28", "2026-06-29",
+                    "2026-06-30", "2026-07-01"):
+            mcp_env.add_sleep_summary(day, avg_hrv_rmssd_ms=50.0)
+        result = await call_tool(mcp_client, "get_daily_readiness_context", {"date": AS_OF})
+        hrv = result["hrv"]
+        assert hrv["status"] == "insufficient_data"
+        assert "stale" in hrv["reason"]
+        assert hrv["stale_days"] == 7
+
+    async def test_sleep_debt_requires_internal_score(self, mcp_client, mcp_env, call_tool):
+        # Defect 7: provider (oura) sleep scores must NOT be used for sleep debt.
+        for day in ("2026-07-06", "2026-07-07", "2026-07-08"):
+            mcp_env.add_score("sleep", "oura", f"{day}T07:00:00+09:00", 70)
+        result = await call_tool(mcp_client, "get_daily_readiness_context", {"date": AS_OF})
+        sleep = result["sleep_debt"]
+        assert sleep["status"] == "insufficient_data"
+        assert sleep["reason"] == "no_internal_sleep_score"
+        assert "index" not in sleep
+
+    async def test_stale_garmin_stress_yields_to_fresh_proxy_baseline(
+        self, mcp_client, mcp_env, call_tool
+    ):
+        # Defect 6: a ~60-day-old Garmin stress must not suppress a fresh proxy
+        # (before the fix `if not daily` used the stale Garmin as "current").
+        mcp_env.add_score("stress", "garmin", "2026-05-09T12:00:00Z", 80)
+        mcp_env.add_score(
+            "resilience", "internal", "2026-07-08T00:00:00Z", 0.12,
+            components={"resilience_score": {"value": 65}},
+        )
+        result = await call_tool(
+            mcp_client, "get_personal_baselines", {"metrics": ["stress"], "as_of": AS_OF}
+        )
+        stress = result["metrics"]["stress"]
+        assert stress["source"] == "internal_resilience_proxy(100-resilience_score)"
+        assert stress["current"]["date"] == "2026-07-08"  # fresh proxy day, not 05-09
+        assert stress["current"]["value"] == 35.0  # 100 - 65
+

--- a/tests/mcp_server/test_tools_insight.py
+++ b/tests/mcp_server/test_tools_insight.py
@@ -480,3 +480,64 @@ class TestStoreSideEffectsUntouched:
         )
         with store_factory() as session:
             assert session.scalars(select(FoodLog)).all() == []
+
+
+class TestReviewFindingFixes:
+    """Regression tests for the independent-review fixes on the insight tools
+    (Defects 4, 8, 9). Env is pinned to KST (UTC+9); DAY is the local test day."""
+
+    async def test_impact_dedupes_by_local_day_before_capping(
+        self, mcp_client, mcp_env, call_tool, store_factory
+    ):
+        # Defect 9: 31 wine logs on ONE local day would monopolize the 30-cap and
+        # starve the min-n gate; dedupe-by-local-day must run BEFORE the cap so
+        # the 4 valid prior days survive. (Old code -> insufficient_data.)
+        for minute in range(31):  # all on local day 07-06 (KST) -- the most recent
+            seed_food(
+                store_factory,
+                f"Red wine {minute}",
+                dt.datetime(2026, 7, 6, 3, minute, tzinfo=dt.UTC),  # 12:mm KST 07-06
+            )
+        for day in (1, 2, 3, 4):  # one wine log on each earlier local day
+            seed_food(
+                store_factory,
+                "Red wine dinner",
+                dt.datetime(2026, 7, day, 3, 0, tzinfo=dt.UTC),  # 12:00 KST 07-0d
+            )
+        for day in range(1, 8):  # internal sleep scores 07-01..07-07 so nights pair
+            mcp_env.add_score("sleep", "internal", f"2026-07-{day:02d}T07:00:00+09:00", 60 + day)
+
+        result = await call_tool(
+            mcp_client,
+            "compare_impact",
+            {"factor": "wine", "metric": "sleep_score", "window": "30d", "end_date": DAY},
+        )
+        assert result["status"] == "ok"
+        assert result["occurrences"]["total_matched"] == 35  # 31 + 4 raw matches
+        assert result["occurrences"]["used"] == 5  # 5 distinct local days survive the cap
+        assert result["occurrences"]["truncated"] is False  # 5 distinct days <= 30
+        assert result["effect"]["n"] == 5  # every survivor pairs
+
+    async def test_stress_timeline_truncation_is_insufficient(
+        self, mcp_client, mcp_env, call_tool
+    ):
+        # Defect 8: a truncated intraday series must not be presented as a full
+        # day. 21 in-window samples, page size 1, default 20-page cap -> truncated.
+        for minute in range(21):
+            mcp_env.add_stress_sample(f"2026-07-08T00:{minute:02d}:00Z", 20 + minute % 5)
+        mcp_env.timeseries_page_size = 1
+        result = await call_tool(mcp_client, "get_stress_timeline", {"date": DAY})
+        assert result["truncated"] is True
+        assert result["status"] == "insufficient_data"
+        assert result["reason"] == "stress_timeseries_truncated"
+
+    async def test_stress_timeline_single_sample_is_insufficient(
+        self, mcp_client, mcp_env, call_tool
+    ):
+        # Defect 4: one sample is not a timeline (>= MIN_TIMELINE_SAMPLES required).
+        mcp_env.add_stress_sample("2026-07-08T00:00:00Z", 42)  # 09:00 KST, in window
+        result = await call_tool(mcp_client, "get_stress_timeline", {"date": DAY})
+        assert result["status"] == "insufficient_data"
+        assert result["reason"] == "insufficient_stress_samples"
+        assert result["intervals"] == []
+


### PR DESCRIPTION
Fixes the defects an **independent gpt-5.6-sol/xhigh review** found across the merged glue plane (the review I ran after the user asked whether merges had been independently reviewed — they hadn't been, so I had GPT review them). 20+ findings, all verified real, fixed with **49 new tests** (923 → 972 green, ruff clean).

## mcp_server — health-interpretation correctness (9)
Timezone: local-day grouping (was UTC-day → wrong-day attribution), IANA-zone system fallback (was a fixed offset, lost DST), UTC-based timeline math (DST-fold safe). Honesty: min-coverage gates so sparse windows/timelines/truncated pages return `insufficient_data` instead of `ok`. Freshness: HRV/current-value staleness gate; stress source chosen by freshness (stale Garmin no longer suppresses the resilience proxy; never mixed); sleep debt requires the internal score (no silent provider fallback); `compare_impact` dedupes by local day before capping.

## calendars — ownership & durability (8)
Forged/stripped ownership tag now requires an `agent_task_id` resolving to a local Task (blocks the agent moving/deleting a **user's** event); `If-Match` on update/delete with `412 → CalendarConflictError`; poll job returns the `SyncDiff` (deletions reach the trigger); `PendingDiffStore` journal (at-least-once); full-resync tombstone reconciliation; per-source state files with unique atomic temps; idempotent proposal push.

## engine / ui / backup (3)
Raising webhook sender no longer burns the dedup key without delivery (native-delivers if enabled, else removes the row to retry next sweep); landing page no longer propagates a visitor `?token` onto `/v1/*` links (no raw-token leak); RemoteVault validates a real age-v1 envelope structure (a forged magic-prefix plaintext can't be uploaded).

Clean per the review: no z-score div0, no raw-series leakage, no XSS/autoescape gap, no alembic/model drift, no tar traversal / pyrage misuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)