### PR TITLE
fix(mcp): make the scheduling tools LLM-drivable (live planner E2E)

### DIFF
--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -385,8 +385,9 @@ def _resolve_goal_ref(
     ``(None, note)`` so the caller can create the task without a goal and
     surface the note for a later relink.
     """
-    if goal_ref is None:
+    if goal_ref is None or not goal_ref.strip():
         return None, None
+    goal_ref = goal_ref.strip()
     try:
         goal_uuid = uuid.UUID(goal_ref)
     except (ValueError, AttributeError, TypeError):
@@ -1758,6 +1759,10 @@ def propose_schedule_blocks(
         if decision_record_id is not None
         else None
     )
+    for block in blocks:
+        # LLMs pass "" instead of null; treat an empty/whitespace task_id as omitted.
+        if block.task_id is not None and not block.task_id.strip():
+            block.task_id = None
     for index, block in enumerate(blocks):
         if block.task_id is None and not (block.title and block.title.strip()):
             raise ToolError(f"blocks[{index}]: give either task_id or a non-empty title")

--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -53,7 +53,7 @@ import httpx
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from healthmes.config import Settings, get_settings, system_timezone
@@ -373,6 +373,36 @@ def _parse_uuid(value: str, field: str) -> uuid.UUID:
         return uuid.UUID(value)
     except (ValueError, AttributeError, TypeError) as exc:
         raise ToolError(f"{field} must be a UUID, got {value!r}") from exc
+
+
+def _resolve_goal_ref(
+    session: Session, goal_ref: str | None
+) -> tuple[uuid.UUID | None, str | None]:
+    """Best-effort weekly_goal resolution for LLM callers.
+
+    Returns ``(goal_uuid, note)``. Accepts a UUID or an exact (case-insensitive)
+    goal title; an unresolvable reference never raises — it yields
+    ``(None, note)`` so the caller can create the task without a goal and
+    surface the note for a later relink.
+    """
+    if goal_ref is None:
+        return None, None
+    try:
+        goal_uuid = uuid.UUID(goal_ref)
+    except (ValueError, AttributeError, TypeError):
+        goal_uuid = None
+    if goal_uuid is not None:
+        if session.get(WeeklyGoal, goal_uuid) is not None:
+            return goal_uuid, None
+        return None, f"weekly_goal {goal_ref!r} not found — task created without a goal"
+    match = session.scalars(
+        select(WeeklyGoal).where(func.lower(WeeklyGoal.title) == goal_ref.strip().lower())
+    ).first()
+    if match is not None:
+        return match.id, None
+    return None, (
+        f"goal_id {goal_ref!r} is not a known goal id or title — task created without a goal"
+    )
 
 
 def _iso_utc(value: dt.datetime | None) -> str | None:
@@ -1564,11 +1594,13 @@ def upsert_task(
     if est_minutes is not None and est_minutes <= 0:
         raise ToolError(f"est_minutes must be positive, got {est_minutes}")
     deadline_dt = _parse_datetime_utc(deadline, "deadline") if deadline is not None else None
-    goal_uuid = _parse_uuid(goal_id, "goal_id") if goal_id is not None else None
 
     with _store_session() as session:
-        if goal_uuid is not None and session.get(WeeklyGoal, goal_uuid) is None:
-            raise ToolError(f"weekly_goal {goal_id} not found")
+        # Lenient goal linking: an LLM often passes a human label ("goal-1") or
+        # a title instead of the UUID. Resolve what we can (UUID or exact
+        # title); an unresolvable ref does NOT fail task creation — the task is
+        # made without a goal and a note is returned so the agent can relink.
+        goal_uuid, goal_note = _resolve_goal_ref(session, goal_id)
 
         if task_id is not None:
             task = session.get(Task, _parse_uuid(task_id, "task_id"))
@@ -1607,7 +1639,10 @@ def upsert_task(
             created = True
         session.flush()
         payload = _serialize_task(task)
-    return {"status": "ok", "created": created, "task": payload}
+    result: dict[str, Any] = {"status": "ok", "created": created, "task": payload}
+    if goal_note is not None:
+        result["goal_note"] = goal_note
+    return result
 
 
 @mcp.tool
@@ -1684,9 +1719,20 @@ def get_schedule(range: str = "7d") -> dict[str, Any]:
 
 
 class ScheduleBlockIn(BaseModel):
-    """One proposed time block for a task (input of propose_schedule_blocks)."""
+    """One proposed time block (input of propose_schedule_blocks).
 
-    task_id: str = Field(description="UUID of an existing task")
+    Give EITHER ``task_id`` (UUID of an existing task) OR ``title`` (a new task
+    is auto-created for the block) — ``title`` is the easy path when you are
+    proposing a plan from scratch.
+    """
+
+    task_id: str | None = Field(default=None, description="UUID of an existing task (optional)")
+    title: str | None = Field(
+        default=None, description="Task title; a task is auto-created when task_id is omitted"
+    )
+    energy_demand: str | None = Field(
+        default=None, description="low / med / high for an auto-created task"
+    )
     start: str = Field(description="Block start, ISO-8601 (naive = UTC)")
     end: str = Field(description="Block end, ISO-8601, after start")
 
@@ -1696,13 +1742,14 @@ def propose_schedule_blocks(
     blocks: list[ScheduleBlockIn],
     decision_record_id: str | None = None,
 ) -> dict[str, Any]:
-    """Propose schedule blocks for tasks (propose-then-confirm gate).
+    """Propose schedule blocks (propose-then-confirm gate).
 
-    Creates schedule proposals in `proposed` state — nothing is written to any
+    Each block targets a task by `task_id` OR carries a `title` (a task is then
+    auto-created) — use `title` to propose a whole plan without pre-creating
+    tasks. Creates proposals in `proposed` state; nothing is written to any
     calendar until the user confirms. Each returned block lists overlapping
-    mirrored calendar events as `conflicts` so clashes are visible before
-    asking. Optionally link the decision_record_id of the reasoning that
-    produced the plan.
+    mirrored calendar events as `conflicts`. Optionally link the
+    decision_record_id of the reasoning that produced the plan.
     """
     if not blocks:
         raise ToolError("blocks must not be empty")
@@ -1711,22 +1758,43 @@ def propose_schedule_blocks(
         if decision_record_id is not None
         else None
     )
-    parsed: list[tuple[uuid.UUID, dt.datetime, dt.datetime]] = []
+    for index, block in enumerate(blocks):
+        if block.task_id is None and not (block.title and block.title.strip()):
+            raise ToolError(f"blocks[{index}]: give either task_id or a non-empty title")
+        if block.energy_demand is not None:
+            ed = "med" if block.energy_demand == "medium" else block.energy_demand
+            if ed not in {e.value for e in EnergyDemand}:
+                raise ToolError(
+                    f"blocks[{index}].energy_demand must be low/med/high, got "
+                    f"{block.energy_demand!r}"
+                )
+    parsed: list[tuple[ScheduleBlockIn, dt.datetime, dt.datetime]] = []
     for index, block in enumerate(blocks):
         start = _parse_datetime_utc(block.start, f"blocks[{index}].start")
         end = _parse_datetime_utc(block.end, f"blocks[{index}].end")
         if end <= start:
             raise ToolError(f"blocks[{index}]: end must be after start")
-        parsed.append((_parse_uuid(block.task_id, f"blocks[{index}].task_id"), start, end))
+        parsed.append((block, start, end))
 
     with _store_session() as session:
         if decision_uuid is not None and session.get(DecisionRecord, decision_uuid) is None:
             raise ToolError(f"decision_record {decision_record_id} not found")
         created: list[dict[str, Any]] = []
-        for task_uuid, start, end in parsed:
-            task = session.get(Task, task_uuid)
-            if task is None:
-                raise ToolError(f"task {task_uuid} not found")
+        for index, (block, start, end) in enumerate(parsed):
+            if block.task_id is not None:
+                task = session.get(Task, _parse_uuid(block.task_id, f"blocks[{index}].task_id"))
+                if task is None:
+                    raise ToolError(f"task {block.task_id} not found")
+            else:
+                ed = "med" if block.energy_demand == "medium" else block.energy_demand
+                task = Task(
+                    title=block.title.strip(),  # type: ignore[union-attr]
+                    energy_demand=EnergyDemand(ed) if ed else EnergyDemand.MED,
+                    status="scheduled",
+                    source=TaskSource.AGENT,
+                )
+                session.add(task)
+                session.flush()
             conflicts = [
                 {
                     "summary": event.summary,

--- a/tests/mcp_server/test_tools_store.py
+++ b/tests/mcp_server/test_tools_store.py
@@ -20,6 +20,7 @@ from healthmes.store import (
     CalendarEventMirror,
     CalendarSource,
     DecisionRecord,
+    EnergyDemand,
     FoodLog,
     ProposalStatus,
     ScheduleProposal,
@@ -98,10 +99,12 @@ class TestUpsertAndListTasks:
             await mcp_client.call_tool(
                 "upsert_task", {"task_id": str(uuid.uuid4()), "status": "done"}
             )
-        with pytest.raises(ToolError, match="weekly_goal"):
-            await mcp_client.call_tool(
-                "upsert_task", {"title": "x", "goal_id": str(uuid.uuid4())}
-            )
+        # An unknown goal_id is lenient now (created with a note), not an error.
+        unknown_goal = await mcp_client.call_tool(
+            "upsert_task", {"title": "x", "goal_id": str(uuid.uuid4())}
+        )
+        assert unknown_goal.data["created"] is True
+        assert "not found" in unknown_goal.data["goal_note"]
         with pytest.raises(ToolError, match="est_minutes"):
             await mcp_client.call_tool("upsert_task", {"title": "x", "est_minutes": 0})
 
@@ -213,9 +216,53 @@ class TestScheduleTools:
             assert len(rows) == 2
             assert all(row.status == ProposalStatus.PROPOSED for row in rows)
 
+    async def test_upsert_task_tolerates_non_uuid_goal_ref(self, mcp_client, call_tool):
+        """An LLM often passes a human label for goal_id; the task is still
+        created (not an error) and a note is returned (docs: live-E2E fix)."""
+        result = await call_tool(
+            mcp_client, "upsert_task", {"title": "논문 리뷰", "goal_id": "goal-1"}
+        )
+        assert result["created"] is True
+        assert "goal-1" in result["goal_note"]
+        assert result["task"]["goal_id"] is None
+
+    async def test_propose_blocks_auto_creates_task_from_title(
+        self, mcp_client, call_tool, store_factory
+    ):
+        """Blocks may carry a title instead of a task_id — a task is auto-created
+        so the agent can propose a plan without the UUID round-trip."""
+        start = dt.datetime.now(dt.UTC).replace(
+            hour=9, minute=0, second=0, microsecond=0
+        ) + dt.timedelta(days=1)
+        result = await call_tool(
+            mcp_client,
+            "propose_schedule_blocks",
+            {
+                "blocks": [
+                    {
+                        "title": "발표 준비",
+                        "energy_demand": "high",
+                        "start": start.isoformat(),
+                        "end": (start + dt.timedelta(minutes=90)).isoformat(),
+                    }
+                ]
+            },
+        )
+        [proposal] = result["proposals"]
+        assert proposal["task_title"] == "발표 준비"
+        assert proposal["proposal_status"] == "proposed"
+        with store_factory() as session:
+            task = session.get(Task, uuid.UUID(proposal["task_id"]))
+            assert task is not None and task.energy_demand == EnergyDemand.HIGH
+
     async def test_propose_blocks_validation(self, mcp_client, call_tool):
         with pytest.raises(ToolError, match="must not be empty"):
             await mcp_client.call_tool("propose_schedule_blocks", {"blocks": []})
+        with pytest.raises(ToolError, match="either task_id or a non-empty title"):
+            await mcp_client.call_tool(
+                "propose_schedule_blocks",
+                {"blocks": [{"start": "2026-07-17T09:00:00", "end": "2026-07-17T10:00:00"}]},
+            )
         created = await call_tool(mcp_client, "upsert_task", {"title": "t"})
         with pytest.raises(ToolError, match="end must be after start"):
             await mcp_client.call_tool(

--- a/tests/mcp_server/test_tools_store.py
+++ b/tests/mcp_server/test_tools_store.py
@@ -251,6 +251,23 @@ class TestScheduleTools:
         [proposal] = result["proposals"]
         assert proposal["task_title"] == "발표 준비"
         assert proposal["proposal_status"] == "proposed"
+
+        # LLMs pass "" instead of null for task_id — treated as omitted.
+        empty = await call_tool(
+            mcp_client,
+            "propose_schedule_blocks",
+            {
+                "blocks": [
+                    {
+                        "task_id": "",
+                        "title": "저녁 러닝",
+                        "start": (start + dt.timedelta(hours=8)).isoformat(),
+                        "end": (start + dt.timedelta(hours=8, minutes=30)).isoformat(),
+                    }
+                ]
+            },
+        )
+        assert empty["proposals"][0]["task_title"] == "저녁 러닝"
         with store_factory() as session:
             task = session.get(Task, uuid.UUID(proposal["task_id"]))
             assert task is not None and task.energy_demand == EnergyDemand.HIGH


### PR DESCRIPTION
A live end-to-end run of the core use case — gpt-5.6 given three weekly goals, told to read the energy forecast and propose an energy-aware schedule — surfaced three integration bugs that mocks never could. The tools were schema-*correct* but not LLM-*drivable*, so the planner loop stalled and created nothing.

- **upsert_task**: a non-UUID/unknown `goal_id` raised. Now resolves a UUID or exact goal title, else creates the task without a goal and returns a `goal_note`.
- **propose_schedule_blocks**: each block required a UUID `task_id`. Now a block may carry a `title` (+ optional `energy_demand`) and the task is auto-created — the agent can propose a whole plan without the create-then-reference round-trip.
- **empty strings**: LLMs pass `task_id=""` / `goal_id=""` instead of null; both are now normalized to omitted.

After the fixes the same run completes cleanly: the agent reads the energy forecast, then persists **8 real energy-aware schedule proposals** (focus blocks for the talks/paper in high-energy windows, 3 workouts in low-energy windows) + decision records with viewer URLs, zero tool errors. Two new store tests cover the lenient goal ref, title-only auto-create, and empty-string task_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)