### PR TITLE
feat(calendars): low-friction connect onboarding (Google 1-click login, iCloud app password)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,14 +88,21 @@ HEALTHMES_QUIET_HOURS_END=07:00
 HEALTHMES_ALERT_DAILY_BUDGET=8
 HEALTHMES_ALERT_COOLDOWN_MINUTES=60
 
-# Calendar mirror backends (docs/PLAN.md §6) — both OFF by default because
-# they need real credentials.
+# Calendar mirror backends (docs/PLAN.md §6) — the low-friction path is
+# `uv run healthmes connect google` / `... connect icloud --username <id>`
+# (docs/DEVELOPMENT.md "캘린더 연결"): a successful connect stores the
+# token/creds under {HEALTHMES_DATA_DIR} and the sync jobs pick it up
+# automatically — none of the flags below need to change. The env settings
+# keep working and override the stored creds file.
 # Google: put the OAuth client secret at {HEALTHMES_DATA_DIR}/google/
-# client_secret.json and run the interactive bootstrap once to mint
-# {HEALTHMES_DATA_DIR}/google/calendar_token.json.
+# client_secret.json (one-time Google Cloud step), then `healthmes connect
+# google` mints {HEALTHMES_DATA_DIR}/google/calendar_token.json.
 HEALTHMES_GOOGLE_CALENDAR_ENABLED=false
 HEALTHMES_GOOGLE_CALENDAR_ID=primary
 HEALTHMES_GOOGLE_POLL_MINUTES=5
+# Optional: where `healthmes connect google` finds the downloaded OAuth
+# client JSON when it is not at the standard data-dir path above.
+#HEALTHMES_GOOGLE_CLIENT_SECRET_FILE=
 # iCloud CalDAV: username = Apple ID email, password = app-specific password
 # minted at https://appleid.apple.com (never the account password).
 HEALTHMES_CALDAV_ENABLED=false

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,8 +36,9 @@ The service exposes `/health`, the REST surface under `/v1/*` (including the
 companion-app glance briefing at `/v1/briefing/glance`), the cognitive-energy
 forecast at `/cognitive-energy/forecast`, the decision viewer at `/decisions`
 + `/decisions/{id}` (Mermaid, served fully locally), the weekly report at
-`/reports/weekly` (+ `.json` twin), and the Layer-B MCP server (Streamable
-HTTP) at exactly `/mcp`.
+`/reports/weekly` (+ `.json` twin), the read-only calendar-connection status
+page at `/connect` (see "캘린더 연결"), and the Layer-B MCP server
+(Streamable HTTP) at exactly `/mcp`.
 
 Background jobs (the 10-minute trigger sweep, the hourly cognitive-energy
 persist and the weekly encrypted backup) are all registered at startup but
@@ -452,6 +453,76 @@ Client caveats worth knowing (all handled by the shipped apps):
 - Push relay (APNs/FCM/WNS) is out of scope **by design** — notification
   delivery is OS-budgeted polling; Telegram is the guaranteed channel.
 
+## 캘린더 연결 (calendar connect)
+
+`healthmes connect` is the low-friction onboarding for the two calendar
+mirrors (docs/PLAN.md §6). A successful connect stores the credential as
+runtime state under `{HEALTHMES_DATA_DIR}` and the sync jobs detect it
+automatically — **no `.env` edit needed** (the `HEALTHMES_GOOGLE_CALENDAR_
+ENABLED` / `HEALTHMES_CALDAV_*` settings keep working and override the stored
+files). Polling itself runs only while the service has
+`HEALTHMES_SCHEDULER_ENABLED=true`. Connection status is also served
+read-only at `GET /connect` (linked from the landing page as "캘린더 연결";
+gated like the other viewer pages, renders no secrets).
+
+### Google Calendar — one-time OAuth client, then one browser login
+
+Honest caveat: Google has no way around a **one-time app registration** for a
+personal installed app — you must create your own OAuth client once. After
+that, connecting (and re-connecting) is a single browser login.
+
+One-time (Google Cloud Console):
+
+1. Open <https://console.cloud.google.com/> and create (or select) a project.
+2. "APIs & Services" → "Library": enable the **Google Calendar API**.
+3. "APIs & Services" → "OAuth consent screen": configure it and add your own
+   Google account as a test user.
+4. "APIs & Services" → "Credentials" → "Create credentials" →
+   "OAuth client ID" → application type **Desktop app**.
+5. Download the client JSON and save it to
+   `{HEALTHMES_DATA_DIR}/google/client_secret.json` (or point
+   `HEALTHMES_GOOGLE_CLIENT_SECRET_FILE` at wherever you keep it).
+
+Then, whenever you want to connect:
+
+```bash
+uv run healthmes connect google      # opens the browser: log in + consent
+```
+
+The token is saved to `{HEALTHMES_DATA_DIR}/google/calendar_token.json`
+(owner-only) and the Google poll job is enabled by its presence. If the
+client secret is missing, the command prints exactly these setup steps.
+
+### iCloud Calendar (CalDAV) — app-specific password only
+
+1. Create an **app-specific password** at <https://appleid.apple.com>
+   (Sign-In and Security → App-Specific Passwords) — never the account
+   password.
+2. Connect (the password is prompted hidden — it never touches argv or shell
+   history — and validated against `caldav.icloud.com` before anything is
+   stored):
+
+```bash
+uv run healthmes connect icloud --username you@icloud.com
+```
+
+On success the credential lands in
+`{HEALTHMES_DATA_DIR}/caldav/credentials.json` with mode 600 and the CalDAV
+poll job is enabled by its presence.
+
+### Status / disconnect
+
+```bash
+uv run healthmes connect status              # which calendars are connected (no secrets)
+uv run healthmes connect disconnect google   # remove the stored token
+uv run healthmes connect disconnect icloud   # remove the stored credentials
+```
+
+Future work (deliberately not built): a hosted "connect with Google" button
+in the web UI would require a registered redirect URI on this service plus
+web-flow secret handling; the `/connect` page therefore shows status +
+instructions only and performs no writes.
+
 ## Real credentials — what needs what
 
 Everything in `tests/` runs offline; the features below only come alive with
@@ -464,8 +535,8 @@ corresponding integrations stay inactive.
 | The agent itself (Claude API) | Anthropic API key | `ANTHROPIC_API_KEY` in `.env` (hermes gateway) |
 | Health data reads (MCP tools, triggers, insights) | open-wearables API key from its developer portal (`:8000/docs`) | `HEALTHMES_OW_API_KEY` (+ `OPEN_WEARABLES_API_KEY` for the vendored MCP server) |
 | Wearable provider syncs | per-provider OAuth apps (Garmin, Oura, ...) | `config/open-wearables.env` (see the vendor backend docs) |
-| Google Calendar mirror | OAuth client secret + one interactive consent | `{HEALTHMES_DATA_DIR}/google/client_secret.json`, then run the installed-app flow once to mint `calendar_token.json`; set `HEALTHMES_GOOGLE_CALENDAR_ENABLED=true` (polled every `HEALTHMES_GOOGLE_POLL_MINUTES` by the in-service scheduler — needs `HEALTHMES_SCHEDULER_ENABLED=true`) |
-| Apple Calendar (iCloud CalDAV) mirror | app-specific password from appleid.apple.com | `HEALTHMES_CALDAV_USERNAME` + `HEALTHMES_CALDAV_APP_PASSWORD`; set `HEALTHMES_CALDAV_ENABLED=true` (polled every `HEALTHMES_CALDAV_POLL_MINUTES` — needs `HEALTHMES_SCHEDULER_ENABLED=true`) |
+| Google Calendar mirror | OAuth client secret + one interactive consent | one-time client secret to `{HEALTHMES_DATA_DIR}/google/client_secret.json`, then `uv run healthmes connect google` (see "캘린더 연결") — the stored token auto-enables the mirror; `HEALTHMES_GOOGLE_CALENDAR_ENABLED=true` still works (polled every `HEALTHMES_GOOGLE_POLL_MINUTES` — needs `HEALTHMES_SCHEDULER_ENABLED=true`) |
+| Apple Calendar (iCloud CalDAV) mirror | app-specific password from appleid.apple.com | `uv run healthmes connect icloud --username <apple-id>` (see "캘린더 연결") — the stored creds file auto-enables the mirror; the env pair `HEALTHMES_CALDAV_USERNAME` + `HEALTHMES_CALDAV_APP_PASSWORD` (+ `HEALTHMES_CALDAV_ENABLED=true`) still works and overrides it (polled every `HEALTHMES_CALDAV_POLL_MINUTES` — needs `HEALTHMES_SCHEDULER_ENABLED=true`) |
 | Proactive alert push (HealthMes -> Hermes) | shared HMAC secret | `HEALTHMES_HERMES_WEBHOOK_SECRET` — generated into `.env` by `scripts/bootstrap.py` |
 | Encrypted backups (CLI + weekly job) | a passphrase you choose (and must not lose) | `HEALTHMES_BACKUP_PASSPHRASE` in `.env`, or `--passphrase-file` |
 | Remote vault replication (ciphertext-only, optional) | S3-compatible bucket + access keys (AWS S3 / Cloudflare R2 / MinIO) | `HEALTHMES_VAULT_BUCKET` (+ `HEALTHMES_VAULT_ENDPOINT`/`_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY`/`_REGION`/`_PREFIX`); opt in with `HEALTHMES_BACKUP_PROVIDER=remote_vault` or `--provider remote` |

--- a/healthmes/__main__.py
+++ b/healthmes/__main__.py
@@ -1,4 +1,4 @@
-"""HealthMes command line: serve the API or manage encrypted backups.
+"""HealthMes command line: serve the API, manage backups, connect calendars.
 
 ``python -m healthmes``            → serve (uvicorn), same as before
 ``python -m healthmes serve``      → serve explicitly
@@ -6,6 +6,16 @@
 ``python -m healthmes backup list``              → list snapshots (no passphrase)
 ``python -m healthmes backup restore <snapshot>``→ inspect; add --yes to apply
 ``python -m healthmes backup push <snapshot>``   → upload one snapshot to the vault
+``python -m healthmes connect google``           → browser OAuth; token saved locally
+``python -m healthmes connect icloud --username <apple-id>`` → app-password prompt
+``python -m healthmes connect status``           → which calendars are connected
+``python -m healthmes connect disconnect google|icloud``     → remove stored creds
+
+Calendar connections are runtime state under ``Settings.data_dir`` (docs/
+PLAN.md §6): once ``connect`` succeeds, the sync jobs pick the backend up
+automatically (healthmes/calendars/jobs.py::enabled_sources) — no ``.env``
+edit needed. Secrets are never taken from argv (the iCloud app password is
+prompted hidden via getpass) and never echoed.
 
 ``create``/``list``/``restore`` accept ``--provider {local,remote}``
 (default: the HEALTHMES_BACKUP_PROVIDER selector, then local). The remote
@@ -22,6 +32,7 @@ and process listings).
 """
 
 import argparse
+import getpass
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -35,6 +46,8 @@ from healthmes.backup.snapshot import (
     resolve_backup_provider_name,
     resolve_passphrase,
 )
+from healthmes.calendars import creds as calendar_creds
+from healthmes.calendars.base import CalendarError
 from healthmes.config import Settings, get_settings, is_loopback_host
 
 if TYPE_CHECKING:  # pragma: no cover — typing only; runtime import stays lazy
@@ -249,6 +262,195 @@ def _cmd_backup_restore(args: argparse.Namespace) -> int:
     return 0
 
 
+# --- calendar connections (healthmes connect ...) ---------------------------
+
+
+GOOGLE_SETUP_INSTRUCTIONS = """\
+One-time Google setup (Google requires registering your own OAuth client;
+there is no way around this for a personal installed app):
+
+  1. Open https://console.cloud.google.com/ and create (or select) a project.
+  2. "APIs & Services" -> "Library": enable the **Google Calendar API**.
+  3. "APIs & Services" -> "OAuth consent screen": configure it and add your
+     own Google account as a test user.
+  4. "APIs & Services" -> "Credentials" -> "Create credentials" ->
+     "OAuth client ID" -> application type **Desktop app**.
+  5. Download the client JSON and save it to:
+       {client_secret_path}
+     (or point HEALTHMES_GOOGLE_CLIENT_SECRET_FILE at wherever you keep it).
+
+Then re-run:  healthmes connect google"""
+
+
+def _google_client_secret(settings: Settings) -> Path | None:
+    """The client secret to use: the data-dir standard path, else the override."""
+    from healthmes.calendars import google as google_calendar
+
+    standard = google_calendar.google_client_secret_path(settings.data_dir)
+    if standard.exists():
+        return standard
+    override = settings.google_client_secret_file
+    if override is not None and Path(override).exists():
+        return Path(override)
+    return None
+
+
+def _google_identity(google_calendar, credentials, calendar_id: str) -> str | None:
+    """Best-effort display identity of the authorized calendar (never fails).
+
+    ``calendars.get('primary')`` returns the account email as the summary for
+    most accounts; any API/permission hiccup degrades to ``None`` — the token
+    is already saved, so the connect must not fail on a cosmetic probe.
+    """
+    try:
+        service = google_calendar.build_calendar_service(credentials)
+        info = service.calendars().get(calendarId=calendar_id).execute()
+        return str(info.get("summary") or info.get("id") or "") or None
+    except Exception:  # noqa: BLE001 - cosmetic probe only
+        return None
+
+
+def _cmd_connect_google(args: argparse.Namespace) -> int:
+    settings = _cli_settings()
+    from healthmes.calendars import google as google_calendar
+
+    token_path = google_calendar.google_token_path(settings.data_dir)
+    if calendar_creds.google_connection_state(settings.data_dir) == "connected":
+        print(f"Google Calendar is already connected (token at {token_path}).")
+        print("To re-authorize, run `healthmes connect disconnect google` first.")
+        return 0
+
+    client_secret = _google_client_secret(settings)
+    if client_secret is None:
+        expected = google_calendar.google_client_secret_path(settings.data_dir)
+        print("error: no Google OAuth client secret found.\n", file=sys.stderr)
+        print(
+            GOOGLE_SETUP_INSTRUCTIONS.format(client_secret_path=expected),
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Opening your browser for Google login + consent ...")
+    credentials = google_calendar.run_installed_app_flow(
+        client_secret, token_path, port=args.port
+    )
+    identity = _google_identity(google_calendar, credentials, settings.google_calendar_id)
+    if identity:
+        print(f"connected as {identity}")
+    else:
+        print("connected")
+    print(f"token saved to {token_path} (owner-only)")
+    print(
+        "Google Calendar sync is now enabled automatically (the poll job "
+        "detects this token; HEALTHMES_GOOGLE_CALENDAR_ENABLED=true also "
+        "works). Polling runs while the service has "
+        "HEALTHMES_SCHEDULER_ENABLED=true."
+    )
+    return 0
+
+
+def _cmd_connect_icloud(args: argparse.Namespace) -> int:
+    settings = _cli_settings()
+    username = args.username.strip()
+    if not username:
+        print("error: --username must be a non-empty Apple ID email", file=sys.stderr)
+        return 1
+    url = (args.url or settings.caldav_url).strip()
+    app_password = getpass.getpass(
+        "App-specific password (hidden; create one at https://appleid.apple.com): "
+    ).strip()
+    if not app_password:
+        print("error: empty password — nothing stored.", file=sys.stderr)
+        return 1
+
+    print(f"validating CalDAV connection to {url} as {username} ...")
+    summary = calendar_creds.validate_caldav_connection(
+        username=username, app_password=app_password, url=url
+    )
+    path = calendar_creds.save_caldav_credentials(
+        settings.data_dir, username=username, app_password=app_password, url=url
+    )
+    print(f"connected as {username} — {summary}")
+    print(f"credentials saved to {path} (owner-only, mode 600)")
+    print(
+        "iCloud calendar sync is now enabled automatically (the poll job "
+        "detects this credentials file; the HEALTHMES_CALDAV_* env vars keep "
+        "working and override it). Polling runs while the service has "
+        "HEALTHMES_SCHEDULER_ENABLED=true."
+    )
+    return 0
+
+
+def _cmd_connect_status(_args: argparse.Namespace) -> int:
+    settings = _cli_settings()
+    from healthmes.calendars import google as google_calendar
+
+    google_state = calendar_creds.google_connection_state(settings.data_dir)
+    token_path = google_calendar.google_token_path(settings.data_dir)
+    if google_state == "connected":
+        print(f"google: connected (token at {token_path})")
+    elif google_state == "invalid":
+        print(
+            "google: not connected — token file exists but is unusable; "
+            "run `healthmes connect disconnect google`, then `healthmes connect google`"
+        )
+    else:
+        print("google: not connected — run `healthmes connect google`")
+    if settings.google_calendar_enabled and google_state != "connected":
+        print(
+            "        note: HEALTHMES_GOOGLE_CALENDAR_ENABLED=true forces the poll "
+            "job on, but it will fail until a token exists"
+        )
+
+    resolved = calendar_creds.resolve_caldav_credentials(settings)
+    if resolved is not None:
+        origin = ".env (HEALTHMES_CALDAV_*)" if resolved.source == "env" else (
+            f"creds file at {calendar_creds.caldav_credentials_path(settings.data_dir)}"
+        )
+        print(f"icloud: connected as {resolved.username} (via {origin})")
+        if resolved.source == "env" and (
+            calendar_creds.load_caldav_credentials(settings.data_dir) is not None
+        ):
+            print("        note: a creds file also exists; the env values override it")
+    else:
+        print(
+            "icloud: not connected — run `healthmes connect icloud "
+            "--username <apple-id>`"
+        )
+    if not settings.scheduler_enabled:
+        print(
+            "note: HEALTHMES_SCHEDULER_ENABLED is false — connected calendars "
+            "are polled only while the service runs with it set to true"
+        )
+    return 0
+
+
+def _cmd_connect_disconnect(args: argparse.Namespace) -> int:
+    settings = _cli_settings()
+    if args.target == "google":
+        from healthmes.calendars import google as google_calendar
+
+        removed = calendar_creds.delete_google_token(settings.data_dir)
+        token_path = google_calendar.google_token_path(settings.data_dir)
+        print(f"removed {token_path}" if removed else "nothing to remove (no stored token)")
+        if settings.google_calendar_enabled:
+            print(
+                "note: HEALTHMES_GOOGLE_CALENDAR_ENABLED=true still forces the "
+                "poll job on; unset it to fully disable"
+            )
+        return 0
+    removed = calendar_creds.delete_caldav_credentials(settings.data_dir)
+    creds_path = calendar_creds.caldav_credentials_path(settings.data_dir)
+    print(f"removed {creds_path}" if removed else "nothing to remove (no stored credentials)")
+    if settings.caldav_username.strip() and settings.caldav_app_password.get_secret_value():
+        print(
+            "note: HEALTHMES_CALDAV_USERNAME/HEALTHMES_CALDAV_APP_PASSWORD are "
+            "still set in the environment/.env and keep the connection alive; "
+            "clear them to fully disconnect"
+        )
+    return 0
+
+
 def _add_passphrase_file(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--passphrase-file",
@@ -324,6 +526,53 @@ def build_parser() -> argparse.ArgumentParser:
     push.add_argument("snapshot", help="Snapshot file path, or bare name in the backup dir.")
     push.set_defaults(func=_cmd_backup_push)
 
+    connect = subparsers.add_parser(
+        "connect",
+        help="Connect calendars: Google (browser OAuth) / iCloud (app-specific password).",
+    )
+    connect_sub = connect.add_subparsers(dest="connect_command", required=True)
+
+    connect_google = connect_sub.add_parser(
+        "google",
+        help="Run the installed-app OAuth flow in your browser; the token is "
+        "saved to {data_dir}/google/calendar_token.json. Requires the one-time "
+        "OAuth client secret (instructions are printed when it is missing).",
+    )
+    connect_google.add_argument(
+        "--port",
+        type=int,
+        default=0,
+        help="Fixed localhost port for the OAuth loopback listener (default: random free port).",
+    )
+    connect_google.set_defaults(func=_cmd_connect_google)
+
+    connect_icloud = connect_sub.add_parser(
+        "icloud",
+        help="Connect iCloud Calendar via CalDAV: prompts (hidden) for an "
+        "app-specific password, validates against the server, then stores the "
+        "credential owner-only under {data_dir}/caldav/.",
+    )
+    connect_icloud.add_argument(
+        "--username", required=True, help="Apple ID email (the iCloud account)."
+    )
+    connect_icloud.add_argument(
+        "--url",
+        default=None,
+        help="CalDAV discovery URL (default: HEALTHMES_CALDAV_URL, i.e. iCloud).",
+    )
+    connect_icloud.set_defaults(func=_cmd_connect_icloud)
+
+    connect_status = connect_sub.add_parser(
+        "status", help="Show which calendars are connected (never prints secrets)."
+    )
+    connect_status.set_defaults(func=_cmd_connect_status)
+
+    connect_disconnect = connect_sub.add_parser(
+        "disconnect", help="Remove the stored token/credentials for one calendar."
+    )
+    connect_disconnect.add_argument("target", choices=("google", "icloud"))
+    connect_disconnect.set_defaults(func=_cmd_connect_disconnect)
+
     return parser
 
 
@@ -333,7 +582,7 @@ def main(argv: list[str] | None = None) -> int:
         return _serve()  # bare `python -m healthmes` keeps serving (compose/dev_mac.sh)
     try:
         return args.func(args)
-    except BackupError as exc:
+    except (BackupError, CalendarError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/healthmes/api/__init__.py
+++ b/healthmes/api/__init__.py
@@ -20,6 +20,7 @@ from healthmes.api import (
     alerts,
     app_usage,
     briefing,
+    connect,
     decisions,
     energy,
     food,
@@ -50,6 +51,7 @@ routers: list[APIRouter] = [
     briefing.router,
     alerts.router,
     reports.router,
+    connect.router,
 ]
 
 

--- a/healthmes/api/auth.py
+++ b/healthmes/api/auth.py
@@ -56,8 +56,11 @@ OPEN_PATHS = frozenset({"/health", "/"})
 # (GET/HEAD only; the middleware never applies the query credential to other
 # methods), so decision/report pages and in-app web views can embed captured
 # photos/voice notes via <img>/<audio> tags. Uploading (POST /v1/media, no
-# trailing slash — not matched by the prefix) stays bearer-only.
-VIEWER_PATH_PREFIXES = ("/decisions", "/static/", "/reports", "/v1/media/")
+# trailing slash — not matched by the prefix) stays bearer-only. "/connect"
+# is the read-only calendar-connection status page (healthmes/api/connect.py
+# — status + instructions, no secrets rendered, no write routes exist under
+# the prefix).
+VIEWER_PATH_PREFIXES = ("/decisions", "/static/", "/reports", "/v1/media/", "/connect")
 
 _VIEWER_TOKEN_CONTEXT = b"healthmes-viewer:"
 

--- a/healthmes/api/connect.py
+++ b/healthmes/api/connect.py
@@ -1,0 +1,153 @@
+"""Calendar-connection status page: ``GET /connect`` (status + instructions only).
+
+Read-only by design. The page performs NO writes, triggers no OAuth flow and
+renders NO secret — not the API token, not OAuth tokens, not app passwords,
+and not even the connected account's username. Connection state is derived
+from file presence / env flags via :mod:`healthmes.calendars.creds` (offline,
+no network). The actual connect/disconnect actions live in the CLI
+(``healthmes connect ...``), which runs on the machine that owns the data dir
+— a hosted web-OAuth button would need a registered redirect URI and secret
+handling inside the service and is deliberately out of scope (noted as future
+work in docs/DEVELOPMENT.md 캘린더 연결).
+
+Gating matches the other human-facing viewer pages (``/decisions``,
+``/reports``): the shared bearer middleware applies, and as a GET page under a
+``VIEWER_PATH_PREFIXES`` entry it additionally accepts the derived read-only
+``?token=`` viewer credential (healthmes/api/auth.py) so a phone browser can
+open it from a link.
+"""
+
+from dataclasses import dataclass
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from healthmes.api.decision_html import shell_context, template_environment
+from healthmes.calendars import creds
+from healthmes.calendars.google import google_client_secret_path, google_token_path
+from healthmes.config import Settings
+
+__all__ = ["router", "build_connection_cards", "ConnectionCard"]
+
+router = APIRouter(tags=["connect"])
+
+CONNECT_PATH = "/connect"
+
+# Exact commands the page shows for not-connected calendars (docs/DEVELOPMENT.md
+# uses `uv run` as the canonical invocation; `healthmes` is the console script).
+GOOGLE_CONNECT_COMMAND = "uv run healthmes connect google"
+ICLOUD_CONNECT_COMMAND = "uv run healthmes connect icloud --username you@icloud.com"
+
+
+@dataclass(frozen=True)
+class ConnectionCard:
+    """Everything the template needs for one calendar — no secret material.
+
+    Every string here is built server-side from static text and data-dir
+    paths; nothing user- or credential-derived ever lands in a field.
+    """
+
+    key: str
+    label: str
+    connected: bool
+    detail: str
+    """Short status line: credential *source* and path — never values."""
+    command: str = ""
+    """Exact CLI command to run when not connected."""
+    steps: tuple[str, ...] = ()
+    """One-time prerequisite steps (Google OAuth-client registration)."""
+    link_label: str = ""
+    link_url: str = ""
+    notes: tuple[str, ...] = ()
+
+
+def _google_card(settings: Settings) -> ConnectionCard:
+    state = creds.google_connection_state(settings.data_dir)
+    token_path = google_token_path(settings.data_dir)
+    client_secret = google_client_secret_path(settings.data_dir)
+    if state == "connected":
+        return ConnectionCard(
+            key="google",
+            label="Google Calendar",
+            connected=True,
+            detail=f"OAuth 토큰 저장됨 · {token_path}",
+        )
+    notes: list[str] = []
+    if state == "invalid":
+        notes.append(
+            "저장된 토큰 파일이 손상되었습니다 — `uv run healthmes connect "
+            "disconnect google` 후 다시 연결하세요."
+        )
+    if settings.google_calendar_enabled:
+        notes.append(
+            "HEALTHMES_GOOGLE_CALENDAR_ENABLED=true 로 폴링은 켜져 있지만, "
+            "토큰이 없어 매 주기 실패합니다."
+        )
+    steps: tuple[str, ...] = ()
+    has_client_secret = client_secret.exists() or (
+        settings.google_client_secret_file is not None
+        and settings.google_client_secret_file.exists()
+    )
+    if not has_client_secret:
+        steps = (
+            "console.cloud.google.com 에서 프로젝트 생성 (또는 선택)",
+            "“APIs & Services → Library”에서 Google Calendar API 활성화",
+            "“OAuth consent screen” 구성 후 본인 계정을 테스트 사용자로 추가",
+            "“Credentials → Create credentials → OAuth client ID”에서 "
+            "유형 “Desktop app”으로 생성",
+            f"내려받은 JSON을 {client_secret} 에 저장",
+        )
+    return ConnectionCard(
+        key="google",
+        label="Google Calendar",
+        connected=False,
+        detail="미연결 — 한 번의 브라우저 로그인으로 연결됩니다.",
+        command=GOOGLE_CONNECT_COMMAND,
+        steps=steps,
+        notes=tuple(notes),
+    )
+
+
+def _icloud_card(settings: Settings) -> ConnectionCard:
+    resolved = creds.resolve_caldav_credentials(settings)
+    if resolved is not None:
+        if resolved.source == "env":
+            detail = "환경변수(.env)의 HEALTHMES_CALDAV_* 자격증명 사용 중"
+        else:
+            detail = (
+                "CLI로 저장된 자격증명 사용 중 · "
+                f"{creds.caldav_credentials_path(settings.data_dir)}"
+            )
+        return ConnectionCard(
+            key="icloud",
+            label="iCloud 캘린더 (CalDAV)",
+            connected=True,
+            detail=detail,
+        )
+    return ConnectionCard(
+        key="icloud",
+        label="iCloud 캘린더 (CalDAV)",
+        connected=False,
+        detail="미연결 — 앱 암호 한 번 입력으로 연결됩니다 (숨김 프롬프트).",
+        command=ICLOUD_CONNECT_COMMAND,
+        link_label="앱 암호 만들기 (appleid.apple.com)",
+        link_url="https://appleid.apple.com",
+    )
+
+
+def build_connection_cards(settings: Settings) -> list[ConnectionCard]:
+    """Connection status of every supported calendar (pure, offline, no secrets)."""
+    return [_google_card(settings), _icloud_card(settings)]
+
+
+@router.get(CONNECT_PATH, response_class=HTMLResponse)
+def connect_status_page(request: Request) -> HTMLResponse:
+    """Human-facing calendar-connection status page (read-only)."""
+    settings: Settings = request.app.state.settings
+    template = template_environment().get_template("ui/connect.html.j2")
+    html = template.render(
+        cards=build_connection_cards(settings),
+        scheduler_enabled=settings.scheduler_enabled,
+        **shell_context(settings),
+    )
+    return HTMLResponse(html)

--- a/healthmes/api/templates/ui/connect.html.j2
+++ b/healthmes/api/templates/ui/connect.html.j2
@@ -1,0 +1,73 @@
+{% extends "ui/_base.html.j2" %}
+{# Calendar-connection STATUS page (healthmes/api/connect.py) — read-only.
+   Renders connection state + the exact CLI commands to run; performs no
+   writes and shows no secret (no tokens, no passwords, no usernames). Every
+   string comes from server-side static text / data-dir paths. #}
+
+{% block title %}캘린더 연결 — HealthMes{% endblock %}
+{% block crumb %}<span class="crumb">/ 캘린더 연결</span>{% endblock %}
+
+{% block head %}
+<style>
+  .conn-badge-on {
+    background: var(--brand-soft); border-color: var(--brand); color: var(--brand-deep);
+  }
+  .conn-badge-off { background: var(--surface-2); color: var(--ink-2); }
+  .conn-cmd {
+    display: block; margin: 0.55rem 0; padding: 0.6rem 0.8rem;
+    background: var(--surface-2); border: 1px solid var(--line-soft);
+    border-radius: var(--radius-sm); overflow-x: auto; white-space: pre;
+  }
+  ol.conn-steps { margin: 0.4rem 0 0.2rem; padding-left: 1.3rem; }
+  ol.conn-steps li { margin: 0.25rem 0; font-size: 0.9rem; }
+  .conn-note { color: var(--ink-2); font-size: 0.86rem; margin: 0.35rem 0; }
+</style>
+{% endblock %}
+
+{% block content %}
+<p class="eyebrow">Calendar connections</p>
+<h1>캘린더 연결</h1>
+<p class="muted">이 페이지는 <strong>상태 표시 전용</strong>입니다 — 연결/해제는 이 기기의
+  터미널에서 실행하며, 토큰·앱 암호 같은 비밀 값은 이 페이지에 절대 표시되지 않습니다.</p>
+{% if not scheduler_enabled %}
+<p class="conn-note">참고: 연결되어 있어도 캘린더 폴링은 서비스가
+  <code>HEALTHMES_SCHEDULER_ENABLED=true</code> 로 실행 중일 때만 동작합니다.</p>
+{% endif %}
+
+{% for cal in cards %}
+<section class="card">
+  <h2>{{ cal.label }}
+    {% if cal.connected %}
+    <span class="badge conn-badge-on">연결됨</span>
+    {% else %}
+    <span class="badge conn-badge-off">미연결</span>
+    {% endif %}
+  </h2>
+  <p class="muted">{{ cal.detail }}</p>
+  {% for note in cal.notes %}
+  <p class="conn-note">{{ note }}</p>
+  {% endfor %}
+  {% if not cal.connected %}
+    {% if cal.steps %}
+    <p>최초 1회 준비 (Google이 요구하는 개인 OAuth 클라이언트 등록):</p>
+    <ol class="conn-steps">
+      {% for step in cal.steps %}
+      <li>{{ step }}</li>
+      {% endfor %}
+    </ol>
+    <p>그 다음, 저장소 루트 터미널에서:</p>
+    {% else %}
+    <p>저장소 루트 터미널에서 아래 명령을 실행하세요:</p>
+    {% endif %}
+    <code class="conn-cmd">{{ cal.command }}</code>
+    {% if cal.link_url %}
+    <p class="conn-note"><a href="{{ cal.link_url }}" rel="noopener noreferrer">{{ cal.link_label }}</a>
+      — Apple 계정 암호가 아닌 <strong>앱 암호</strong>를 사용합니다.</p>
+    {% endif %}
+  {% endif %}
+</section>
+{% endfor %}
+
+<p class="muted">연결 확인/해제: <code>uv run healthmes connect status</code> ·
+  <code>uv run healthmes connect disconnect google|icloud</code></p>
+{% endblock %}

--- a/healthmes/api/templates/ui/index.html.j2
+++ b/healthmes/api/templates/ui/index.html.j2
@@ -75,6 +75,11 @@
       <p>컴패니언 앱이 읽는 지금-상태 스냅샷 (JSON).</p>
       <code>GET /v1/briefing/glance</code>
     </a>
+    <a class="surface-card" href="/connect">
+      <h2>캘린더 연결</h2>
+      <p>Google · iCloud 캘린더 연결 상태와 연결 방법 (읽기 전용).</p>
+      <code>GET /connect</code>
+    </a>
     <a class="surface-card" href="/docs">
       <h2>API 문서</h2>
       <p>REST 전체 표면의 OpenAPI 문서.</p>

--- a/healthmes/calendars/creds.py
+++ b/healthmes/calendars/creds.py
@@ -1,0 +1,271 @@
+"""Runtime calendar-connection credentials (the ``healthmes connect`` layer).
+
+docs/PLAN.md §6 keeps calendar credentials runtime-only. This module is the
+single place that decides whether a calendar is *connected* and where the
+secret material for a runtime connection lives:
+
+- **Google** — the OAuth token minted by the installed-app flow at
+  ``{data_dir}/google/calendar_token.json`` (healthmes/calendars/google.py).
+  "Connected" is judged offline: the file parses as an authorized-user
+  document carrying the refresh material Google needs. No google imports, no
+  network — the sync job still refreshes (and may fail) at runtime as before.
+- **iCloud CalDAV** — ``{data_dir}/caldav/credentials.json`` written by
+  ``healthmes connect icloud`` (owner-only, mode 600). The env settings
+  (``HEALTHMES_CALDAV_USERNAME`` + ``HEALTHMES_CALDAV_APP_PASSWORD``) keep
+  working and OVERRIDE the file when both are set —
+  :func:`resolve_caldav_credentials` is the one resolution point the backend
+  builder consumes.
+
+Security rules enforced here: credential files are created owner-only from
+the first byte (``os.open`` with mode 0600, then an atomic replace), nothing
+in this module ever logs or returns a secret except
+:func:`resolve_caldav_credentials`/:func:`load_caldav_credentials` (whose
+callers are the backend builder and the CLI), and error messages scrub the
+app password defensively.
+"""
+
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from healthmes.calendars.base import CalendarAuthError, CalendarError
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from healthmes.config import Settings
+
+__all__ = [
+    "CalDavCredentials",
+    "GoogleConnectionState",
+    "caldav_credentials_path",
+    "delete_caldav_credentials",
+    "delete_google_token",
+    "google_connected",
+    "google_connection_state",
+    "load_caldav_credentials",
+    "resolve_caldav_credentials",
+    "save_caldav_credentials",
+    "validate_caldav_connection",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Offline judgement of the stored Google authorization (no network):
+#: ``connected`` (token file parses with refresh material), ``invalid``
+#: (file present but unusable — re-run ``healthmes connect google``) or
+#: ``not_connected`` (no token file).
+GoogleConnectionState = Literal["connected", "invalid", "not_connected"]
+
+# Keys google.oauth2.credentials.Credentials.from_authorized_user_info
+# requires to refresh non-interactively; a token file missing any of them
+# cannot survive expiry and counts as broken.
+_GOOGLE_REFRESH_KEYS = ("refresh_token", "client_id", "client_secret")
+
+
+@dataclass(frozen=True, slots=True)
+class CalDavCredentials:
+    """One resolved CalDAV credential set (values are secret — never log)."""
+
+    username: str
+    app_password: str
+    url: str
+    source: Literal["env", "file"]
+
+
+# --- iCloud CalDAV credentials file ------------------------------------------
+
+
+def caldav_credentials_path(data_dir: Path) -> Path:
+    """Owner-only credentials file written by ``healthmes connect icloud``."""
+    return Path(data_dir) / "caldav" / "credentials.json"
+
+
+def _write_owner_only_json(path: Path, payload: dict) -> None:
+    """Write JSON created with mode 0600 from the first byte, then swap atomically.
+
+    ``os.open`` with the restrictive mode means there is never a window where
+    the secret is world-readable; the unique temp name + ``os.replace``
+    mirrors healthmes/calendars/state.py so a crash never leaves a torn file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    os.replace(tmp_path, path)
+    path.chmod(0o600)  # replace preserves the temp's 0600; re-assert anyway
+
+
+def save_caldav_credentials(
+    data_dir: Path, *, username: str, app_password: str, url: str
+) -> Path:
+    """Persist an iCloud/CalDAV credential set owner-only; returns the path."""
+    if not username.strip():
+        raise CalendarError("caldav username must be non-empty")
+    if not app_password:
+        raise CalendarError("caldav app password must be non-empty")
+    path = caldav_credentials_path(data_dir)
+    _write_owner_only_json(
+        path, {"username": username, "app_password": app_password, "url": url}
+    )
+    return path
+
+
+def load_caldav_credentials(data_dir: Path) -> CalDavCredentials | None:
+    """Read the stored CalDAV credentials; ``None`` when absent or unusable.
+
+    A corrupt/incomplete file degrades to "not connected" (with a warning that
+    names the path, never the contents) instead of failing the caller.
+    """
+    path = caldav_credentials_path(data_dir)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        logger.warning("unreadable caldav credentials file %s", path)
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning(
+            "corrupt caldav credentials file %s; re-run `healthmes connect icloud`", path
+        )
+        return None
+    if not isinstance(data, dict):
+        logger.warning("malformed caldav credentials file %s", path)
+        return None
+    username = str(data.get("username") or "").strip()
+    app_password = str(data.get("app_password") or "")
+    if not username or not app_password:
+        logger.warning("incomplete caldav credentials file %s", path)
+        return None
+    return CalDavCredentials(
+        username=username,
+        app_password=app_password,
+        url=str(data.get("url") or "").strip(),
+        source="file",
+    )
+
+
+def delete_caldav_credentials(data_dir: Path) -> bool:
+    """Remove the stored CalDAV credentials; True when a file was deleted."""
+    path = caldav_credentials_path(data_dir)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def resolve_caldav_credentials(settings: "Settings") -> CalDavCredentials | None:
+    """The single CalDAV credential resolution point (env first, then file).
+
+    Env wins when BOTH ``caldav_username`` and ``caldav_app_password`` are set
+    (the pre-existing configuration path, unchanged); otherwise the creds file
+    written by ``healthmes connect icloud`` is used. ``None`` = not connected.
+    """
+    env_username = settings.caldav_username.strip()
+    env_password = settings.caldav_app_password.get_secret_value().strip()
+    if env_username and env_password:
+        return CalDavCredentials(
+            username=env_username,
+            app_password=env_password,
+            url=settings.caldav_url,
+            source="env",
+        )
+    stored = load_caldav_credentials(settings.data_dir)
+    if stored is None:
+        return None
+    if not stored.url:
+        stored = CalDavCredentials(
+            username=stored.username,
+            app_password=stored.app_password,
+            url=settings.caldav_url,
+            source="file",
+        )
+    return stored
+
+
+def validate_caldav_connection(*, username: str, app_password: str, url: str) -> str:
+    """Open a real CalDAV session and discover the principal's calendars.
+
+    Returns a short human description of what was found (calendar names only —
+    never credentials). Raises :class:`CalendarAuthError` when the server
+    rejects the login or discovery fails, with the app password scrubbed from
+    the message defensively. Mirrors the discovery
+    :meth:`CalDavCalendarBackend.connect` performs, so a passing validation
+    means the sync backend will connect the same way.
+    """
+    import caldav
+
+    try:
+        client = caldav.DAVClient(url=url, username=username, password=app_password)
+        principal = client.principal()
+        calendars = principal.calendars()
+    except Exception as exc:  # noqa: BLE001 - library raises broad errors
+        detail = str(exc).replace(app_password, "***") or type(exc).__name__
+        raise CalendarAuthError(
+            f"CalDAV login/discovery failed for {username} at {url}: {detail}"
+        ) from exc
+    if not calendars:
+        raise CalendarError(
+            f"CalDAV login succeeded but no calendars are visible at {url}"
+        )
+    names = [str(getattr(cal, "name", None) or "?") for cal in calendars]
+    shown = ", ".join(names[:3]) + (" …" if len(names) > 3 else "")
+    return f"{len(calendars)} calendar(s): {shown}"
+
+
+# --- Google token (offline connection judgement) ------------------------------
+
+
+def google_connection_state(data_dir: Path) -> GoogleConnectionState:
+    """Offline judgement of the stored Google authorization (no network).
+
+    ``connected`` when the token file parses as an authorized-user JSON with
+    the refresh material google-auth needs; ``invalid`` when a file exists but
+    is unusable; ``not_connected`` when there is no token file. Deliberately
+    import-free of the google libraries so status checks stay instant.
+    """
+    from healthmes.calendars.google import google_token_path
+
+    path = google_token_path(data_dir)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "not_connected"
+    except OSError:
+        return "invalid"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return "invalid"
+    if not isinstance(data, dict):
+        return "invalid"
+    if all(str(data.get(key) or "").strip() for key in _GOOGLE_REFRESH_KEYS):
+        return "connected"
+    return "invalid"
+
+
+def google_connected(data_dir: Path) -> bool:
+    """True when a usable Google authorization is stored under ``data_dir``."""
+    return google_connection_state(data_dir) == "connected"
+
+
+def delete_google_token(data_dir: Path) -> bool:
+    """Remove the stored Google token; True when a file was deleted."""
+    from healthmes.calendars.google import google_token_path
+
+    try:
+        google_token_path(data_dir).unlink()
+    except FileNotFoundError:
+        return False
+    return True

--- a/healthmes/calendars/jobs.py
+++ b/healthmes/calendars/jobs.py
@@ -4,10 +4,14 @@ This is the production entry point of the calendar plane — the piece that
 turns the (fully tested) backend/service library into running behavior:
 
 - :func:`build_calendar_jobs` returns one :class:`CalendarJobSpec` per
-  *enabled* backend (``Settings.google_calendar_enabled`` /
-  ``Settings.caldav_enabled``), polling at ``google_poll_minutes`` /
-  ``caldav_poll_minutes`` (PLAN §6: 5 / 10 minutes). The app lifespan
-  registers each spec on the in-process scheduler.
+  *enabled* backend, polling at ``google_poll_minutes`` /
+  ``caldav_poll_minutes`` (PLAN §6: 5 / 10 minutes). A backend is enabled by
+  its settings flag (``Settings.google_calendar_enabled`` /
+  ``Settings.caldav_enabled``) OR by a runtime connection established with
+  ``healthmes connect`` — i.e. the token/creds file under ``Settings.data_dir``
+  exists (healthmes/calendars/creds.py) — so connecting via the CLI needs no
+  ``.env`` edit. The app lifespan registers each spec on the in-process
+  scheduler.
 - Every run syncs that backend into ``calendar_event_mirror`` (the trigger
   sweep's ``schedule_changed`` rule and the energy engine's meeting-load
   factor read the mirror; the sync itself is enough — no push here).
@@ -30,7 +34,8 @@ from dataclasses import dataclass
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
-from healthmes.calendars.base import CalendarBackend, EventDraft, coerce_utc
+from healthmes.calendars import creds
+from healthmes.calendars.base import CalendarAuthError, CalendarBackend, EventDraft, coerce_utc
 from healthmes.calendars.state import (
     FilePendingDiffStore,
     FileSyncStateStore,
@@ -70,11 +75,19 @@ def calendar_job_id(source: CalendarSource) -> str:
 
 
 def enabled_sources(settings: Settings) -> tuple[CalendarSource, ...]:
-    """Backends enabled by settings, in write-preference order (Google first)."""
+    """Backends enabled by settings OR connected via ``healthmes connect``.
+
+    Write-preference order (Google first). "Connected" means the runtime
+    token/creds file under ``Settings.data_dir`` exists and is usable
+    (healthmes/calendars/creds.py) — establishing a connection with the CLI
+    is enough, no ``.env`` edit required. The settings flags keep working
+    and force a backend on even without a stored file (its poll then fails
+    per-run until credentials appear, exactly as before).
+    """
     sources: list[CalendarSource] = []
-    if settings.google_calendar_enabled:
+    if settings.google_calendar_enabled or creds.google_connected(settings.data_dir):
         sources.append(CalendarSource.GOOGLE)
-    if settings.caldav_enabled:
+    if settings.caldav_enabled or creds.load_caldav_credentials(settings.data_dir) is not None:
         sources.append(CalendarSource.CALDAV)
     return tuple(sources)
 
@@ -96,10 +109,17 @@ def _build_backend(settings: Settings, source: CalendarSource) -> CalendarBacken
         )
     from healthmes.calendars.caldav_icloud import CalDavCalendarBackend
 
+    resolved = creds.resolve_caldav_credentials(settings)
+    if resolved is None:
+        raise CalendarAuthError(
+            "no CalDAV credentials: set HEALTHMES_CALDAV_USERNAME + "
+            "HEALTHMES_CALDAV_APP_PASSWORD, or run `healthmes connect icloud "
+            "--username <apple-id>` once"
+        )
     return CalDavCalendarBackend.connect(
-        username=settings.caldav_username,
-        app_password=settings.caldav_app_password.get_secret_value(),
-        url=settings.caldav_url,
+        username=resolved.username,
+        app_password=resolved.app_password,
+        url=resolved.url,
         calendar_name=settings.caldav_calendar_name,
     )
 

--- a/healthmes/config.py
+++ b/healthmes/config.py
@@ -168,6 +168,13 @@ class Settings(BaseSettings):
         default="primary",
         description="Google calendar id to mirror ('primary' or a specific calendar's id).",
     )
+    google_client_secret_file: Path | None = Field(
+        default=None,
+        description="Optional path to a Google OAuth client-secret JSON, used by "
+        "`healthmes connect google` when {data_dir}/google/client_secret.json "
+        "is absent (the standard location keeps working; this is an override "
+        "for keeping the download wherever you like).",
+    )
     google_poll_minutes: int = Field(
         default=5,
         ge=1,
@@ -278,6 +285,7 @@ class Settings(BaseSettings):
         "backup_dir",
         "ow_database_url",
         "hermes_home",
+        "google_client_secret_file",
         "backup_provider",
         "vault_endpoint",
         "vault_bucket",

--- a/tests/api/test_connect.py
+++ b/tests/api/test_connect.py
@@ -1,0 +1,111 @@
+"""``GET /connect`` — read-only calendar-connection status page.
+
+Pins: 200 with per-calendar connected/not-connected state derived from fake
+creds files, the exact CLI commands for the not-connected ones, NO secret in
+the markup (no app password, no token contents, not even the username), and
+viewer-page gating (401 bare / 200 with the derived ?token= or the bearer —
+same posture as /decisions).
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from healthmes.api.auth import viewer_token
+from healthmes.app import create_app
+from healthmes.calendars import creds
+
+TOKEN = "connect-page-api-token"
+APP_PASSWORD = "abcd-efgh-ijkl-mnop"
+REFRESH_TOKEN = "fake-refresh-token-value"
+
+
+@pytest.fixture
+def client(app):
+    """Status page served by the shared api-test app (tokenless settings)."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def connect_google(data_dir) -> None:
+    token = data_dir / "google" / "calendar_token.json"
+    token.parent.mkdir(parents=True, exist_ok=True)
+    token.write_text(
+        json.dumps(
+            {
+                "type": "authorized_user",
+                "refresh_token": REFRESH_TOKEN,
+                "client_id": "x.apps.googleusercontent.com",
+                "client_secret": "fake-client-secret-value",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def connect_icloud(data_dir) -> None:
+    creds.save_caldav_credentials(
+        data_dir,
+        username="me@icloud.com",
+        app_password=APP_PASSWORD,
+        url="https://caldav.icloud.com",
+    )
+
+
+def test_not_connected_shows_exact_commands(client) -> None:
+    response = client.get("/connect")
+    assert response.status_code == 200
+    text = response.text
+    assert "미연결" in text
+    assert "uv run healthmes connect google" in text
+    assert "uv run healthmes connect icloud --username you@icloud.com" in text
+    # The one-time Google prerequisite and the iCloud app-password source.
+    assert "console.cloud.google.com" in text
+    assert "appleid.apple.com" in text
+
+
+def test_connected_states_render_without_secrets(client, settings) -> None:
+    connect_google(settings.data_dir)
+    connect_icloud(settings.data_dir)
+    response = client.get("/connect")
+    assert response.status_code == 200
+    text = response.text
+    assert text.count("연결됨") == 2
+    assert "미연결" not in text
+    # No secret material — and not even the account identifier — renders.
+    assert APP_PASSWORD not in text
+    assert REFRESH_TOKEN not in text
+    assert "fake-client-secret-value" not in text
+    assert "me@icloud.com" not in text
+
+
+def test_mixed_state_renders_per_calendar(client, settings) -> None:
+    connect_icloud(settings.data_dir)
+    text = client.get("/connect").text
+    assert "연결됨" in text and "미연결" in text
+    assert "uv run healthmes connect google" in text
+    assert "uv run healthmes connect icloud" not in text  # connected: no command
+
+
+def test_gating_matches_viewer_pages(settings) -> None:
+    secured = settings.model_copy(update={"api_token": SecretStr(TOKEN)})
+    with TestClient(create_app(secured)) as client:
+        assert client.get("/connect").status_code == 401
+        assert client.get("/connect", params={"token": "wrong"}).status_code == 401
+
+        via_viewer_token = client.get("/connect", params={"token": viewer_token(TOKEN)})
+        assert via_viewer_token.status_code == 200
+        assert TOKEN not in via_viewer_token.text  # raw API token never renders
+
+        via_bearer = client.get(
+            "/connect", headers={"Authorization": f"Bearer {TOKEN}"}
+        )
+        assert via_bearer.status_code == 200
+
+
+def test_landing_links_to_connect(client) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'href="/connect"' in response.text

--- a/tests/api/test_wiring.py
+++ b/tests/api/test_wiring.py
@@ -31,11 +31,12 @@ EXPECTED_PATHS = [
     "/v1/briefing/glance",
     "/reports/weekly",
     "/reports/weekly.json",
+    "/connect",
 ]
 
 
 def test_routers_list_covers_all_modules():
-    assert len(routers) == 13
+    assert len(routers) == 14
 
 
 def test_openapi_schema_generates_with_all_paths(client):

--- a/tests/connect/test_cli.py
+++ b/tests/connect/test_cli.py
@@ -1,0 +1,283 @@
+"""CLI tests: ``healthmes connect google|icloud|status|disconnect``.
+
+All offline: the CalDAV validation and the Google OAuth flow are
+monkeypatched fakes; credentials come from fake token/creds files. The suite
+pins the security contract — the app password is prompted hidden (never
+argv), the creds file lands owner-only (0600), and no secret value ever
+appears on stdout/stderr.
+"""
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from healthmes.__main__ import main
+from healthmes.calendars import creds
+from healthmes.calendars.base import CalendarAuthError
+
+APP_PASSWORD = "abcd-efgh-ijkl-mnop"
+REFRESH_TOKEN = "fake-refresh-token-value"
+
+
+@pytest.fixture
+def connect_env(tmp_path, monkeypatch) -> Path:
+    """CLI environment: tmp cwd (no repo .env) + tmp data dir via env vars."""
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("HEALTHMES_DATA_DIR", str(data_dir))
+    for var in (
+        "HEALTHMES_CALDAV_USERNAME",
+        "HEALTHMES_CALDAV_APP_PASSWORD",
+        "HEALTHMES_CALDAV_ENABLED",
+        "HEALTHMES_CALDAV_URL",
+        "HEALTHMES_GOOGLE_CALENDAR_ENABLED",
+        "HEALTHMES_GOOGLE_CLIENT_SECRET_FILE",
+        "HEALTHMES_SCHEDULER_ENABLED",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return data_dir
+
+
+def write_google_token(data_dir: Path) -> Path:
+    token = data_dir / "google" / "calendar_token.json"
+    token.parent.mkdir(parents=True, exist_ok=True)
+    token.write_text(
+        json.dumps(
+            {
+                "type": "authorized_user",
+                "refresh_token": REFRESH_TOKEN,
+                "client_id": "x.apps.googleusercontent.com",
+                "client_secret": "fake-client-secret-value",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return token
+
+
+class TestStatus:
+    def test_nothing_connected(self, connect_env, capsys) -> None:
+        assert main(["connect", "status"]) == 0
+        out = capsys.readouterr().out
+        assert "google: not connected" in out
+        assert "icloud: not connected" in out
+
+    def test_connected_states_never_print_secrets(self, connect_env, capsys) -> None:
+        write_google_token(connect_env)
+        creds.save_caldav_credentials(
+            connect_env,
+            username="me@icloud.com",
+            app_password=APP_PASSWORD,
+            url="https://caldav.icloud.com",
+        )
+        assert main(["connect", "status"]) == 0
+        out = capsys.readouterr().out
+        assert "google: connected" in out
+        assert "icloud: connected as me@icloud.com" in out
+        assert APP_PASSWORD not in out
+        assert REFRESH_TOKEN not in out
+
+    def test_broken_google_token_reported(self, connect_env, capsys) -> None:
+        token = connect_env / "google" / "calendar_token.json"
+        token.parent.mkdir(parents=True)
+        token.write_text("{broken", encoding="utf-8")
+        assert main(["connect", "status"]) == 0
+        out = capsys.readouterr().out
+        assert "google: not connected" in out
+        assert "unusable" in out
+
+
+class TestConnectICloud:
+    def test_connect_writes_owner_only_creds(self, connect_env, capsys, monkeypatch) -> None:
+        received = {}
+
+        def fake_validate(*, username: str, app_password: str, url: str) -> str:
+            received.update(username=username, app_password=app_password, url=url)
+            return "2 calendar(s): 가족, 업무"
+
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": APP_PASSWORD + "\n")
+        monkeypatch.setattr(
+            "healthmes.calendars.creds.validate_caldav_connection", fake_validate
+        )
+
+        assert main(["connect", "icloud", "--username", "me@icloud.com"]) == 0
+
+        # The prompted (stripped) password reached the real-connection check...
+        assert received == {
+            "username": "me@icloud.com",
+            "app_password": APP_PASSWORD,
+            "url": "https://caldav.icloud.com",
+        }
+        # ...and was persisted owner-only.
+        path = creds.caldav_credentials_path(connect_env)
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        stored = json.loads(path.read_text(encoding="utf-8"))
+        assert stored["username"] == "me@icloud.com"
+        assert stored["app_password"] == APP_PASSWORD
+        captured = capsys.readouterr()
+        assert "connected as me@icloud.com" in captured.out
+        assert APP_PASSWORD not in captured.out + captured.err  # never echoed
+
+    def test_validation_failure_stores_nothing(self, connect_env, capsys, monkeypatch) -> None:
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": APP_PASSWORD)
+
+        def failing_validate(**_kwargs):
+            raise CalendarAuthError("CalDAV login/discovery failed: 401 unauthorized")
+
+        monkeypatch.setattr(
+            "healthmes.calendars.creds.validate_caldav_connection", failing_validate
+        )
+
+        assert main(["connect", "icloud", "--username", "me@icloud.com"]) == 1
+        captured = capsys.readouterr()
+        assert "error:" in captured.err
+        assert APP_PASSWORD not in captured.out + captured.err
+        assert not creds.caldav_credentials_path(connect_env).exists()
+
+    def test_empty_password_aborts(self, connect_env, capsys, monkeypatch) -> None:
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "  ")
+        monkeypatch.setattr(
+            "healthmes.calendars.creds.validate_caldav_connection",
+            lambda **_kw: pytest.fail("validation must not run on an empty password"),
+        )
+        assert main(["connect", "icloud", "--username", "me@icloud.com"]) == 1
+        assert "empty password" in capsys.readouterr().err
+        assert not creds.caldav_credentials_path(connect_env).exists()
+
+
+class TestConnectGoogle:
+    def test_missing_client_secret_prints_instructions(self, connect_env, capsys) -> None:
+        assert main(["connect", "google"]) == 1
+        err = capsys.readouterr().err
+        assert "console.cloud.google.com" in err
+        assert str(connect_env / "google" / "client_secret.json") in err
+        assert "Desktop app" in err
+        assert "HEALTHMES_GOOGLE_CLIENT_SECRET_FILE" in err
+
+    def test_connect_runs_installed_app_flow(self, connect_env, capsys, monkeypatch) -> None:
+        client_secret = connect_env / "google" / "client_secret.json"
+        client_secret.parent.mkdir(parents=True)
+        client_secret.write_text(json.dumps({"installed": {"client_id": "x"}}), encoding="utf-8")
+        calls = {}
+
+        def fake_flow(client_secret_file, token_file, scopes=None, *, port=0):
+            calls["client_secret"] = Path(client_secret_file)
+            calls["token_file"] = Path(token_file)
+            calls["port"] = port
+            write_google_token(connect_env)
+            return object()
+
+        monkeypatch.setattr("healthmes.calendars.google.run_installed_app_flow", fake_flow)
+        # The identity probe degrades gracefully when the API is unreachable.
+        monkeypatch.setattr(
+            "healthmes.calendars.google.build_calendar_service",
+            lambda credentials: (_ for _ in ()).throw(RuntimeError("offline")),
+        )
+
+        assert main(["connect", "google"]) == 0
+        assert calls["client_secret"] == client_secret
+        assert calls["token_file"] == connect_env / "google" / "calendar_token.json"
+        out = capsys.readouterr().out
+        assert "connected" in out
+        assert "token saved to" in out
+
+    def test_connect_reports_identity_when_probe_works(
+        self, connect_env, capsys, monkeypatch
+    ) -> None:
+        client_secret = connect_env / "google" / "client_secret.json"
+        client_secret.parent.mkdir(parents=True)
+        client_secret.write_text("{}", encoding="utf-8")
+
+        def fake_flow(client_secret_file, token_file, scopes=None, *, port=0):
+            write_google_token(connect_env)
+            return object()
+
+        class FakeCalendars:
+            def get(self, calendarId):  # noqa: N803 - google API parameter name
+                assert calendarId == "primary"
+                return self
+
+            def execute(self):
+                return {"summary": "me@gmail.com"}
+
+        class FakeService:
+            def calendars(self):
+                return FakeCalendars()
+
+        monkeypatch.setattr("healthmes.calendars.google.run_installed_app_flow", fake_flow)
+        monkeypatch.setattr(
+            "healthmes.calendars.google.build_calendar_service", lambda c: FakeService()
+        )
+
+        assert main(["connect", "google"]) == 0
+        out = capsys.readouterr().out
+        assert "connected as me@gmail.com" in out
+        assert REFRESH_TOKEN not in out
+
+    def test_client_secret_override_via_env(
+        self, connect_env, capsys, monkeypatch, tmp_path
+    ) -> None:
+        elsewhere = tmp_path / "downloads" / "oauth-client.json"
+        elsewhere.parent.mkdir(parents=True)
+        elsewhere.write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("HEALTHMES_GOOGLE_CLIENT_SECRET_FILE", str(elsewhere))
+        calls = {}
+
+        def fake_flow(client_secret_file, token_file, scopes=None, *, port=0):
+            calls["client_secret"] = Path(client_secret_file)
+            write_google_token(connect_env)
+            return object()
+
+        monkeypatch.setattr("healthmes.calendars.google.run_installed_app_flow", fake_flow)
+        monkeypatch.setattr(
+            "healthmes.calendars.google.build_calendar_service",
+            lambda c: (_ for _ in ()).throw(RuntimeError("offline")),
+        )
+
+        assert main(["connect", "google"]) == 0
+        assert calls["client_secret"] == elsewhere
+
+    def test_already_connected_skips_flow(self, connect_env, capsys, monkeypatch) -> None:
+        write_google_token(connect_env)
+        monkeypatch.setattr(
+            "healthmes.calendars.google.run_installed_app_flow",
+            lambda *a, **kw: pytest.fail("flow must not run when already connected"),
+        )
+        assert main(["connect", "google"]) == 0
+        assert "already connected" in capsys.readouterr().out
+
+
+class TestDisconnect:
+    def test_disconnect_google_removes_token(self, connect_env, capsys) -> None:
+        token = write_google_token(connect_env)
+        assert main(["connect", "disconnect", "google"]) == 0
+        assert not token.exists()
+        assert "removed" in capsys.readouterr().out
+        # Idempotent second run.
+        assert main(["connect", "disconnect", "google"]) == 0
+        assert "nothing to remove" in capsys.readouterr().out
+
+    def test_disconnect_icloud_removes_creds(self, connect_env, capsys) -> None:
+        creds.save_caldav_credentials(
+            connect_env, username="me@icloud.com", app_password=APP_PASSWORD, url="https://c.test"
+        )
+        assert main(["connect", "disconnect", "icloud"]) == 0
+        assert not creds.caldav_credentials_path(connect_env).exists()
+        out = capsys.readouterr().out
+        assert "removed" in out
+        assert APP_PASSWORD not in out
+
+    def test_disconnect_icloud_warns_when_env_still_configured(
+        self, connect_env, capsys, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("HEALTHMES_CALDAV_USERNAME", "env@icloud.com")
+        monkeypatch.setenv("HEALTHMES_CALDAV_APP_PASSWORD", "env-pw")
+        creds.save_caldav_credentials(
+            connect_env, username="me@icloud.com", app_password=APP_PASSWORD, url="https://c.test"
+        )
+        assert main(["connect", "disconnect", "icloud"]) == 0
+        out = capsys.readouterr().out
+        assert "HEALTHMES_CALDAV_USERNAME" in out
+        assert "env-pw" not in out

--- a/tests/connect/test_creds.py
+++ b/tests/connect/test_creds.py
@@ -1,0 +1,205 @@
+"""Creds-layer tests (healthmes/calendars/creds.py).
+
+Pin the security and resolution contract of the runtime connection layer:
+credential files are owner-only (0600) from creation, corrupt/missing files
+degrade to "not connected" (never an exception in the resolution path), and
+env settings override the file — the pre-existing configuration path must
+keep working unchanged.
+"""
+
+import json
+import stat
+
+import pytest
+from pydantic import SecretStr
+
+from healthmes.calendars import creds
+from healthmes.calendars.base import CalendarError
+
+PASSWORD = "abcd-efgh-ijkl-mnop"
+
+
+def file_mode(path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def write_google_token(data_dir, payload) -> None:
+    token = data_dir / "google" / "calendar_token.json"
+    token.parent.mkdir(parents=True, exist_ok=True)
+    token.write_text(
+        payload if isinstance(payload, str) else json.dumps(payload), encoding="utf-8"
+    )
+
+
+class TestCalDavCredsFile:
+    def test_save_writes_owner_only_file(self, tmp_path) -> None:
+        path = creds.save_caldav_credentials(
+            tmp_path,
+            username="me@icloud.com",
+            app_password=PASSWORD,
+            url="https://caldav.icloud.com",
+        )
+        assert path == creds.caldav_credentials_path(tmp_path)
+        assert file_mode(path) == 0o600
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data == {
+            "username": "me@icloud.com",
+            "app_password": PASSWORD,
+            "url": "https://caldav.icloud.com",
+        }
+
+    def test_roundtrip(self, tmp_path) -> None:
+        creds.save_caldav_credentials(
+            tmp_path, username="me@icloud.com", app_password=PASSWORD, url="https://c.test"
+        )
+        loaded = creds.load_caldav_credentials(tmp_path)
+        assert loaded is not None
+        assert loaded.username == "me@icloud.com"
+        assert loaded.app_password == PASSWORD
+        assert loaded.url == "https://c.test"
+        assert loaded.source == "file"
+
+    def test_save_overwrite_keeps_owner_only(self, tmp_path) -> None:
+        creds.save_caldav_credentials(
+            tmp_path, username="a@icloud.com", app_password="one", url="https://c.test"
+        )
+        path = creds.save_caldav_credentials(
+            tmp_path, username="b@icloud.com", app_password="two", url="https://c.test"
+        )
+        assert file_mode(path) == 0o600
+        loaded = creds.load_caldav_credentials(tmp_path)
+        assert loaded is not None and loaded.username == "b@icloud.com"
+
+    def test_save_rejects_empty_values(self, tmp_path) -> None:
+        with pytest.raises(CalendarError):
+            creds.save_caldav_credentials(
+                tmp_path, username="  ", app_password=PASSWORD, url="https://c.test"
+            )
+        with pytest.raises(CalendarError):
+            creds.save_caldav_credentials(
+                tmp_path, username="me@icloud.com", app_password="", url="https://c.test"
+            )
+        assert not creds.caldav_credentials_path(tmp_path).exists()
+
+    def test_load_missing_returns_none(self, tmp_path) -> None:
+        assert creds.load_caldav_credentials(tmp_path) is None
+
+    def test_load_corrupt_returns_none(self, tmp_path) -> None:
+        path = creds.caldav_credentials_path(tmp_path)
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert creds.load_caldav_credentials(tmp_path) is None
+
+    def test_load_incomplete_returns_none(self, tmp_path) -> None:
+        path = creds.caldav_credentials_path(tmp_path)
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps({"username": "me@icloud.com"}), encoding="utf-8")
+        assert creds.load_caldav_credentials(tmp_path) is None
+
+    def test_delete(self, tmp_path) -> None:
+        creds.save_caldav_credentials(
+            tmp_path, username="me@icloud.com", app_password=PASSWORD, url="https://c.test"
+        )
+        assert creds.delete_caldav_credentials(tmp_path) is True
+        assert creds.load_caldav_credentials(tmp_path) is None
+        assert creds.delete_caldav_credentials(tmp_path) is False
+
+
+class TestResolveCalDav:
+    def test_none_when_nothing_configured(self, settings) -> None:
+        assert creds.resolve_caldav_credentials(settings) is None
+
+    def test_file_used_when_env_unset(self, settings) -> None:
+        creds.save_caldav_credentials(
+            settings.data_dir,
+            username="file@icloud.com",
+            app_password="file-pw",
+            url="https://caldav.file",
+        )
+        resolved = creds.resolve_caldav_credentials(settings)
+        assert resolved is not None
+        assert resolved.source == "file"
+        assert resolved.username == "file@icloud.com"
+        assert resolved.app_password == "file-pw"
+        assert resolved.url == "https://caldav.file"
+
+    def test_env_overrides_file(self, settings) -> None:
+        creds.save_caldav_credentials(
+            settings.data_dir,
+            username="file@icloud.com",
+            app_password="file-pw",
+            url="https://caldav.file",
+        )
+        env_settings = settings.model_copy(
+            update={
+                "caldav_username": "env@icloud.com",
+                "caldav_app_password": SecretStr("env-pw"),
+            }
+        )
+        resolved = creds.resolve_caldav_credentials(env_settings)
+        assert resolved is not None
+        assert resolved.source == "env"
+        assert resolved.username == "env@icloud.com"
+        assert resolved.app_password == "env-pw"
+        assert resolved.url == env_settings.caldav_url
+
+    def test_partial_env_falls_back_to_file(self, settings) -> None:
+        # Username alone in env is not a usable credential set; the stored
+        # file (a complete set) wins over mixing the two.
+        creds.save_caldav_credentials(
+            settings.data_dir,
+            username="file@icloud.com",
+            app_password="file-pw",
+            url="https://caldav.file",
+        )
+        partial = settings.model_copy(update={"caldav_username": "env@icloud.com"})
+        resolved = creds.resolve_caldav_credentials(partial)
+        assert resolved is not None and resolved.source == "file"
+
+    def test_file_without_url_uses_settings_url(self, settings) -> None:
+        path = creds.caldav_credentials_path(settings.data_dir)
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"username": "file@icloud.com", "app_password": "file-pw"}),
+            encoding="utf-8",
+        )
+        resolved = creds.resolve_caldav_credentials(settings)
+        assert resolved is not None
+        assert resolved.url == settings.caldav_url
+
+
+class TestGoogleConnectionState:
+    def test_not_connected_without_token_file(self, tmp_path) -> None:
+        assert creds.google_connection_state(tmp_path) == "not_connected"
+        assert creds.google_connected(tmp_path) is False
+
+    def test_connected_with_refresh_material(self, tmp_path) -> None:
+        write_google_token(
+            tmp_path,
+            {
+                "type": "authorized_user",
+                "refresh_token": "fake-refresh",
+                "client_id": "x.apps.googleusercontent.com",
+                "client_secret": "fake-secret",
+            },
+        )
+        assert creds.google_connection_state(tmp_path) == "connected"
+        assert creds.google_connected(tmp_path) is True
+
+    def test_invalid_when_garbage(self, tmp_path) -> None:
+        write_google_token(tmp_path, "{broken")
+        assert creds.google_connection_state(tmp_path) == "invalid"
+        assert creds.google_connected(tmp_path) is False
+
+    def test_invalid_without_refresh_token(self, tmp_path) -> None:
+        write_google_token(
+            tmp_path,
+            {"type": "authorized_user", "client_id": "x", "client_secret": "y"},
+        )
+        assert creds.google_connection_state(tmp_path) == "invalid"
+
+    def test_delete_google_token(self, tmp_path) -> None:
+        write_google_token(tmp_path, {"refresh_token": "r", "client_id": "c", "client_secret": "s"})
+        assert creds.delete_google_token(tmp_path) is True
+        assert creds.google_connection_state(tmp_path) == "not_connected"
+        assert creds.delete_google_token(tmp_path) is False

--- a/tests/connect/test_jobs_pickup.py
+++ b/tests/connect/test_jobs_pickup.py
@@ -1,0 +1,128 @@
+"""Sync jobs pick up runtime connections established via ``healthmes connect``.
+
+Pins the contract of docs/PLAN.md §6 + the connect onboarding: "connected" =
+the token/creds file under ``Settings.data_dir`` exists — no ``.env`` edit
+needed — while the pre-existing env-based path keeps working and env
+credentials override the file.
+"""
+
+import json
+
+import pytest
+from pydantic import SecretStr
+
+from healthmes.calendars import creds, jobs
+from healthmes.calendars.base import CalendarAuthError
+from healthmes.store.enums import CalendarSource
+
+
+def write_google_token(data_dir) -> None:
+    token = data_dir / "google" / "calendar_token.json"
+    token.parent.mkdir(parents=True, exist_ok=True)
+    token.write_text(
+        json.dumps(
+            {
+                "type": "authorized_user",
+                "refresh_token": "fake-refresh",
+                "client_id": "x.apps.googleusercontent.com",
+                "client_secret": "fake-secret",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestRuntimeEnablement:
+    def test_caldav_creds_file_enables_without_flag(self, settings) -> None:
+        creds.save_caldav_credentials(
+            settings.data_dir,
+            username="me@icloud.com",
+            app_password="pw",
+            url="https://caldav.test",
+        )
+        assert jobs.enabled_sources(settings) == (CalendarSource.CALDAV,)
+        assert jobs.write_source(settings) is CalendarSource.CALDAV
+        specs = jobs.build_calendar_jobs(settings)
+        assert [spec.source for spec in specs] == [CalendarSource.CALDAV]
+        assert specs[0].interval_minutes == settings.caldav_poll_minutes
+
+    def test_google_token_enables_without_flag(self, settings) -> None:
+        write_google_token(settings.data_dir)
+        assert jobs.enabled_sources(settings) == (CalendarSource.GOOGLE,)
+        assert jobs.write_source(settings) is CalendarSource.GOOGLE
+
+    def test_both_runtime_connections_keep_google_as_writer(self, settings) -> None:
+        write_google_token(settings.data_dir)
+        creds.save_caldav_credentials(
+            settings.data_dir, username="me@icloud.com", app_password="pw", url="https://c.test"
+        )
+        assert jobs.enabled_sources(settings) == (
+            CalendarSource.GOOGLE,
+            CalendarSource.CALDAV,
+        )
+        assert jobs.write_source(settings) is CalendarSource.GOOGLE
+
+    def test_broken_google_token_does_not_enable(self, settings) -> None:
+        token = settings.data_dir / "google" / "calendar_token.json"
+        token.parent.mkdir(parents=True)
+        token.write_text("{broken", encoding="utf-8")
+        assert jobs.enabled_sources(settings) == ()
+
+    def test_env_flags_still_enable_without_files(self, settings) -> None:
+        enabled = settings.model_copy(
+            update={"google_calendar_enabled": True, "caldav_enabled": True}
+        )
+        assert jobs.enabled_sources(enabled) == (
+            CalendarSource.GOOGLE,
+            CalendarSource.CALDAV,
+        )
+
+
+class TestBackendCredsResolution:
+    @pytest.fixture
+    def captured_connect(self, monkeypatch) -> dict:
+        captured: dict = {}
+
+        def fake_connect(**kwargs):
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(
+            "healthmes.calendars.caldav_icloud.CalDavCalendarBackend.connect",
+            staticmethod(fake_connect),
+        )
+        return captured
+
+    def test_file_creds_used_when_env_unset(self, settings, captured_connect) -> None:
+        creds.save_caldav_credentials(
+            settings.data_dir,
+            username="file@icloud.com",
+            app_password="file-pw",
+            url="https://caldav.file",
+        )
+        jobs._build_backend(settings, CalendarSource.CALDAV)
+        assert captured_connect["username"] == "file@icloud.com"
+        assert captured_connect["app_password"] == "file-pw"
+        assert captured_connect["url"] == "https://caldav.file"
+
+    def test_env_creds_override_file(self, settings, captured_connect) -> None:
+        creds.save_caldav_credentials(
+            settings.data_dir,
+            username="file@icloud.com",
+            app_password="file-pw",
+            url="https://caldav.file",
+        )
+        env_settings = settings.model_copy(
+            update={
+                "caldav_username": "env@icloud.com",
+                "caldav_app_password": SecretStr("env-pw"),
+            }
+        )
+        jobs._build_backend(env_settings, CalendarSource.CALDAV)
+        assert captured_connect["username"] == "env@icloud.com"
+        assert captured_connect["app_password"] == "env-pw"
+        assert captured_connect["url"] == env_settings.caldav_url
+
+    def test_no_credentials_raises_pointer_to_connect(self, settings) -> None:
+        with pytest.raises(CalendarAuthError, match="connect icloud"):
+            jobs._build_backend(settings, CalendarSource.CALDAV)


### PR DESCRIPTION
Makes connecting a calendar minimal for the user, per request. After a one-time Google OAuth-client registration (Google's own unavoidable requirement, documented crisply), connecting is:

- **CLI** (`healthmes connect ...`): `google` runs the installed-app browser-login flow (token saved 0600); `icloud --username <appleid>` takes a hidden app-password prompt, validates against caldav.icloud.com, and persists creds 0600; plus `status` and `disconnect`.
- **No .env edit needed**: a runtime connection (token/creds file present) enables the source — `enabled_sources()` ORs the settings flag with file presence; env still overrides file values.
- **`GET /connect`**: a read-only status page (connected/not + the exact command + the one-time Google steps), viewer-token gated like `/decisions`, renders zero secrets; linked from the landing page.
- **docs**: a 캘린더 연결 section (the one-time Google step + the two commands + the iCloud app-password link).

Security: passwords/tokens never logged, echoed, or rendered; creds files are 0600; `/connect` performs no writes. A hosted web-OAuth button for future end-users is deferred (needs a registered redirect URI) and documented as such.

1019 tests green (45 new), ruff clean; `/connect` verified live on the tunneled host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)