### PR TITLE
feat(connect): packaged Google OAuth client fallback

### DIFF
--- a/healthmes/__main__.py
+++ b/healthmes/__main__.py
@@ -285,7 +285,15 @@ Then re-run:  healthmes connect google"""
 
 
 def _google_client_secret(settings: Settings) -> Path | None:
-    """The client secret to use: the data-dir standard path, else the override."""
+    """The client secret to use: data-dir standard path → env override →
+    the packaged project client (config/google_oauth_client.json).
+
+    The packaged fallback is the gcloud/rclone installed-app pattern: the
+    project ships its own OAuth desktop client so a new user's
+    ``connect google`` is a browser login and nothing else — no console
+    registration (PLAN §13). Desktop-app client identifiers are not
+    confidential in Google's model; the account still consents in-browser.
+    """
     from healthmes.calendars import google as google_calendar
 
     standard = google_calendar.google_client_secret_path(settings.data_dir)
@@ -294,6 +302,9 @@ def _google_client_secret(settings: Settings) -> Path | None:
     override = settings.google_client_secret_file
     if override is not None and Path(override).exists():
         return Path(override)
+    packaged = Path(__file__).resolve().parent.parent / "config" / "google_oauth_client.json"
+    if packaged.exists():
+        return packaged
     return None
 
 


### PR DESCRIPTION
config/google_oauth_client.json이 저장소에 존재하면 connect google이 그것을 폴백으로 사용 — 신규 사용자는 콘솔 등록 없이 브라우저 로그인만으로 캘린더 연동(PLAN §13, gcloud/rclone 패턴). data-dir/env 경로가 우선.

실제 클라이언트 JSON 커밋은 소유자 승인 필요(권한 정책상 제가 못 넣음): `git add -f config/google_oauth_client.json` 후 푸시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)