### PR TITLE
feat(pairing): connect qr — scan-to-pair for companion/bridge apps

### DIFF
--- a/healthmes/__main__.py
+++ b/healthmes/__main__.py
@@ -479,6 +479,26 @@ def _cmd_import_apple(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_connect_qr(_args: argparse.Namespace) -> int:
+    settings = _cli_settings()
+    from healthmes.pairing import build_pairing_url, render_terminal_qr
+
+    payload = build_pairing_url(settings)
+    print(render_terminal_qr(payload))
+    print(f"payload: {payload}")
+    if not settings.api_token.get_secret_value().strip():
+        print(
+            "note: no HEALTHMES_API_TOKEN configured — the QR pairs URL only "
+            "(fine for a loopback-only instance)."
+        )
+    print(
+        "Scan with the HealthMes companion app, or copy the url/token into "
+        "a bridge app (e.g. Health Auto Export → REST API target "
+        f"{settings.public_base_url.rstrip('/')}/v1/ingest/healthkit)."
+    )
+    return 0
+
+
 def _add_passphrase_file(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--passphrase-file",
@@ -600,6 +620,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     connect_disconnect.add_argument("target", choices=("google", "icloud"))
     connect_disconnect.set_defaults(func=_cmd_connect_disconnect)
+
+    connect_qr = connect_sub.add_parser(
+        "qr",
+        help="Show the pairing QR (base URL + bearer token) for companion "
+        "and bridge apps — scan instead of typing.",
+    )
+    connect_qr.set_defaults(func=_cmd_connect_qr)
 
     import_parser = subparsers.add_parser(
         "import",

--- a/healthmes/pairing.py
+++ b/healthmes/pairing.py
@@ -1,0 +1,43 @@
+"""Companion-app pairing payload (docs/PLAN.md §13 — QR onboarding).
+
+The companion apps (and bridge apps like Health Auto Export) need exactly
+two values: the instance base URL and the bearer token. ``healthmes connect
+qr`` renders them as one scannable QR so nobody types a 64-char token on a
+phone keyboard.
+
+Payload format: ``healthmes://pair?url=<base>&token=<bearer>`` — the same
+custom scheme the iOS/Android companions already register for deep links
+(``apps/ios-companion/project.yml``); the ``pair`` route lands app-side with
+the deferred HealthKit module work. Until then the QR's human-visible
+fallback (printed next to it) is copy-paste friendly.
+
+The token is embedded on purpose: pairing IS credential handoff. The QR is
+drawn on the terminal of the machine that already owns the token and never
+persisted, logged, or served over HTTP.
+"""
+
+from urllib.parse import quote
+
+from healthmes.config import Settings
+
+
+def build_pairing_url(settings: Settings) -> str:
+    """The ``healthmes://pair`` deep link for this instance."""
+    base = settings.public_base_url.rstrip("/")
+    token = settings.api_token.get_secret_value().strip()
+    url = f"healthmes://pair?url={quote(base, safe='')}"
+    if token:
+        url += f"&token={quote(token, safe='')}"
+    return url
+
+
+def render_terminal_qr(payload: str) -> str:
+    """The payload as a compact terminal QR block (ANSI half-blocks)."""
+    import io
+
+    import segno
+
+    qr = segno.make(payload, error="m")
+    buffer = io.StringIO()
+    qr.terminal(out=buffer, compact=True, border=2)
+    return buffer.getvalue()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     # Multipart parsing for the capture upload (POST /v1/media, issue #10) —
     # previously only a transitive dep of fastmcp; FastAPI needs it directly.
     "python-multipart>=0.0.32",
+    "segno>=1.6.6",
 ]
 
 [project.scripts]

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,0 +1,29 @@
+"""Pairing payload + QR rendering (healthmes/pairing.py)."""
+
+from pydantic import SecretStr
+
+from healthmes.pairing import build_pairing_url, render_terminal_qr
+
+
+def test_pairing_url_encodes_base_and_token(settings):
+    s2 = settings.model_copy(
+        update={
+            "public_base_url": "https://healthmes.example.com/",
+            "api_token": SecretStr("tok/with+special=chars"),
+        }
+    )
+    url = build_pairing_url(s2)
+    assert url.startswith("healthmes://pair?url=https%3A%2F%2Fhealthmes.example.com")
+    assert "token=tok%2Fwith%2Bspecial%3Dchars" in url
+    assert "/" not in url.split("url=")[1].split("&")[0]
+
+
+def test_pairing_url_omits_empty_token(settings):
+    url = build_pairing_url(settings)  # conftest: api_token=""
+    assert "token=" not in url
+    assert url == "healthmes://pair?url=http%3A%2F%2Fhealthmes.test%3A8100"
+
+
+def test_terminal_qr_renders(settings):
+    block = render_terminal_qr(build_pairing_url(settings))
+    assert len(block.splitlines()) > 10  # a real QR block, not an empty string

--- a/uv.lock
+++ b/uv.lock
@@ -765,6 +765,7 @@ dependencies = [
     { name = "pyrage" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "segno" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -798,6 +799,7 @@ requires-dist = [
     { name = "pyrage" },
     { name = "python-multipart", specifier = ">=0.0.32" },
     { name = "pyyaml" },
+    { name = "segno", specifier = ">=1.6.6" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"] },
 ]
@@ -2199,6 +2201,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "segno"
+version = "1.6.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/2e/b396f750c53f570055bf5a9fc1ace09bed2dff013c73b7afec5702a581ba/segno-1.6.6.tar.gz", hash = "sha256:e60933afc4b52137d323a4434c8340e0ce1e58cec71439e46680d4db188f11b3", size = 1628586, upload-time = "2025-03-12T22:12:53.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/02/12c73fd423eb9577b97fc1924966b929eff7074ae6b2e15dd3d30cb9e4ae/segno-1.6.6-py3-none-any.whl", hash = "sha256:28c7d081ed0cf935e0411293a465efd4d500704072cdb039778a2ab8736190c7", size = 76503, upload-time = "2025-03-12T22:12:48.106Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
터미널 QR로 base URL+토큰 페어링 (수동 타이핑 제거, PLAN §13). segno 의존성 추가. 테스트 3개.

🤖 Generated with [Claude Code](https://claude.com/claude-code)