### PR TITLE
feat(arousal): 비-가민 낮 시간대 각성 힌트 — raw 심박 해석 모듈 (Layer B) + 스킬 보강

### DIFF
--- a/healthmes/mcp_server/arousal.py
+++ b/healthmes/mcp_server/arousal.py
@@ -1,0 +1,301 @@
+"""HR-based daytime arousal hints for non-Garmin wearables (PLAN §13 follow-up).
+
+Garmin is the only provider that measures intraday stress natively (§1.5).
+Every other watch (Apple, Galaxy, …) still measures **continuous heart
+rate**, and a heart rate well above the personal resting baseline during a
+*quiet* stretch (no steps, no workout, waking hours) is an honest, weaker
+signal: physiological arousal. It cannot distinguish stress from caffeine,
+heat, or excitement — so this module deliberately produces *hints*, never
+stress claims, and the skill layer is contractually forbidden from basing a
+plan decision on hints alone.
+
+Pipeline (pure functions, no I/O — the MCP layer fetches):
+
+1. ``quiet_windows``  — waking-hour stretches with ~zero steps, outside
+   workout spans. Night hours are excluded as likely sleep (approximation,
+   documented; sleep-event masking is a future refinement — hence the
+   confidence cap).
+2. ``resting_baseline`` — median + spread of the last 14 daily resting-HR
+   values (provider-computed RHR; needs ``MIN_BASELINE_DAYS`` to exist).
+3. ``arousal_hint_intervals`` — sustained (≥ ``MIN_HINT_MINUTES``) runs of
+   quiet-window HR at or above baseline + margin.
+4. ``build_arousal_hints`` — the response payload with coverage, capped
+   confidence, and honest ``insufficient_data``.
+
+All thresholds are named constants and are expert-tunable placeholders per
+the PLAN convention — values chosen to be conservative (few false hints)
+rather than sensitive.
+"""
+
+import datetime as dt
+import statistics
+from dataclasses import dataclass
+from typing import Any
+
+# Expert-tunable placeholders (PLAN §1.5 confidence-boundary convention).
+QUIET_STEP_THRESHOLD = 5  # steps per sample bucket at or below → "still"
+MIN_QUIET_MINUTES = 15  # a stillness stretch shorter than this is ignored
+MIN_HINT_MINUTES = 10  # sustained elevation required for one hint
+HINT_GAP_TOLERANCE_MINUTES = 3  # brief dips/missing samples inside a run
+AROUSAL_MARGIN_BPM = 12.0  # elevation over resting baseline that counts
+MIN_BASELINE_DAYS = 7  # fewer RHR days → insufficient_data
+WAKING_START_HOUR = 7  # local; earlier is treated as likely sleep
+WAKING_END_HOUR = 23
+MIN_COVERAGE_FOR_MEDIUM = 0.30  # of the waking window observed while quiet
+MIN_COVERAGE = 0.10  # below → insufficient_data
+MEAL_CONTEXT_WINDOW_MINUTES = 45  # food_log entries this close are context
+
+STATUS_OK = "ok"
+STATUS_INSUFFICIENT = "insufficient_data"
+
+
+@dataclass(frozen=True)
+class HintInterval:
+    """One sustained quiet-time HR elevation (hint-grade, never a claim)."""
+
+    start: dt.datetime
+    end: dt.datetime
+    hr_mean: float
+    hr_peak: float
+    baseline_bpm: float
+
+    @property
+    def minutes(self) -> float:
+        return (self.end - self.start).total_seconds() / 60.0
+
+
+def _merge_spans(
+    spans: list[tuple[dt.datetime, dt.datetime]],
+) -> list[tuple[dt.datetime, dt.datetime]]:
+    merged: list[tuple[dt.datetime, dt.datetime]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def waking_window(day: dt.date, tz: dt.tzinfo) -> tuple[dt.datetime, dt.datetime]:
+    """The local waking span used for coverage and likely-sleep exclusion."""
+    return (
+        dt.datetime.combine(day, dt.time(WAKING_START_HOUR), tzinfo=tz),
+        dt.datetime.combine(day, dt.time(WAKING_END_HOUR), tzinfo=tz),
+    )
+
+
+def quiet_windows(
+    step_samples: list[tuple[dt.datetime, float]],
+    workout_spans: list[tuple[dt.datetime, dt.datetime]],
+    day: dt.date,
+    tz: dt.tzinfo,
+) -> list[tuple[dt.datetime, dt.datetime]]:
+    """Waking stretches that are still (≈no steps) and outside workouts.
+
+    Step samples are bucketed observations ``(local_time, steps)``; a gap in
+    step data is NOT treated as stillness — only observed ≤threshold buckets
+    qualify, so missing data lowers coverage instead of inventing quiet.
+    """
+    wake_start, wake_end = waking_window(day, tz)
+    workout_merged = _merge_spans(list(workout_spans))
+
+    ordered = sorted(step_samples)
+    still: list[tuple[dt.datetime, dt.datetime]] = []
+    for index, (at, steps) in enumerate(ordered):
+        if steps > QUIET_STEP_THRESHOLD:
+            continue
+        if not (wake_start <= at < wake_end):
+            continue
+        if any(start <= at < end for start, end in workout_merged):
+            continue
+        # A bucket covers until the next sample (bounded to 15 min so sparse
+        # data cannot claim long stillness).
+        if index + 1 < len(ordered):
+            span_end = min(ordered[index + 1][0], at + dt.timedelta(minutes=15))
+        else:
+            span_end = at + dt.timedelta(minutes=15)
+        still.append((at, min(span_end, wake_end)))
+
+    merged = _merge_spans(still)
+    min_span = dt.timedelta(minutes=MIN_QUIET_MINUTES)
+    return [(start, end) for start, end in merged if end - start >= min_span]
+
+
+def resting_baseline(daily_rhr: list[tuple[dt.date, float]]) -> dict[str, Any] | None:
+    """Median resting HR over the trailing window; None when too thin."""
+    values = [value for _, value in daily_rhr if value > 0]
+    if len(values) < MIN_BASELINE_DAYS:
+        return None
+    return {
+        "median_bpm": statistics.median(values),
+        "days": len(values),
+    }
+
+
+def arousal_hint_intervals(
+    hr_samples: list[tuple[dt.datetime, float]],
+    quiet: list[tuple[dt.datetime, dt.datetime]],
+    baseline_bpm: float,
+) -> list[HintInterval]:
+    """Sustained quiet-time HR runs at or above baseline + margin."""
+    threshold = baseline_bpm + AROUSAL_MARGIN_BPM
+    gap = dt.timedelta(minutes=HINT_GAP_TOLERANCE_MINUTES)
+    min_len = dt.timedelta(minutes=MIN_HINT_MINUTES)
+
+    in_quiet = [
+        (at, value)
+        for at, value in sorted(hr_samples)
+        if any(start <= at < end for start, end in quiet)
+    ]
+
+    hints: list[HintInterval] = []
+    run: list[tuple[dt.datetime, float]] = []
+    for at, value in in_quiet:
+        if value >= threshold:
+            if run and at - run[-1][0] > gap:
+                _flush_run(run, baseline_bpm, min_len, hints)
+                run = []
+            run.append((at, value))
+        elif run and at - run[-1][0] <= gap:
+            continue  # brief dip inside the tolerance window
+        else:
+            _flush_run(run, baseline_bpm, min_len, hints)
+            run = []
+    _flush_run(run, baseline_bpm, min_len, hints)
+    return hints
+
+
+def _flush_run(
+    run: list[tuple[dt.datetime, float]],
+    baseline_bpm: float,
+    min_len: dt.timedelta,
+    out: list[HintInterval],
+) -> None:
+    if len(run) < 2:
+        return
+    start, end = run[0][0], run[-1][0]
+    if end - start < min_len:
+        return
+    values = [value for _, value in run]
+    out.append(
+        HintInterval(
+            start=start,
+            end=end,
+            hr_mean=sum(values) / len(values),
+            hr_peak=max(values),
+            baseline_bpm=baseline_bpm,
+        )
+    )
+
+
+def quiet_coverage(
+    quiet: list[tuple[dt.datetime, dt.datetime]],
+    hr_samples: list[tuple[dt.datetime, float]],
+    day: dt.date,
+    tz: dt.tzinfo,
+) -> float:
+    """Fraction of the waking window that is quiet AND has HR observations."""
+    wake_start, wake_end = waking_window(day, tz)
+    waking_seconds = (wake_end - wake_start).total_seconds()
+    if waking_seconds <= 0:
+        return 0.0
+    hr_times = sorted(at for at, _ in hr_samples)
+    covered = 0.0
+    for start, end in quiet:
+        inside = [at for at in hr_times if start <= at < end]
+        if len(inside) >= 2:
+            covered += (min(end, inside[-1] + dt.timedelta(minutes=5)) - start).total_seconds()
+    return max(0.0, min(1.0, covered / waking_seconds))
+
+
+def meal_context(
+    hint: HintInterval, meals: list[tuple[dt.datetime, str]]
+) -> list[str]:
+    """Food/caffeine log entries close enough to be plausible context."""
+    window = dt.timedelta(minutes=MEAL_CONTEXT_WINDOW_MINUTES)
+    labels = []
+    for logged_at, description in meals:
+        if hint.start - window <= logged_at <= hint.end + window:
+            labels.append(f"meal/log: {description}")
+    return labels
+
+
+def build_arousal_hints(
+    *,
+    day: dt.date,
+    tz: dt.tzinfo,
+    hr_samples: list[tuple[dt.datetime, float]],
+    step_samples: list[tuple[dt.datetime, float]],
+    workout_spans: list[tuple[dt.datetime, dt.datetime]],
+    daily_rhr: list[tuple[dt.date, float]],
+    truncated: bool,
+    context_for: Any,
+    meals: list[tuple[dt.datetime, str]],
+) -> dict[str, Any]:
+    """The ``arousal_hints`` payload attached to ``get_stress_timeline``.
+
+    ``context_for(start, end) -> list[str]`` supplies calendar/app-usage
+    context (the caller closes over its already-fetched rows); meal-log
+    context is appended here. Always returns a dict — failure modes are
+    honest statuses, never exceptions.
+    """
+
+    def insufficient(reason: str) -> dict[str, Any]:
+        return {
+            "status": STATUS_INSUFFICIENT,
+            "reason": reason,
+            "confidence": "low",
+            "coverage": 0.0,
+            "intervals": [],
+            "note": (
+                "Arousal hints need continuous HR, step stillness evidence, "
+                "and a resting-HR baseline; they are hints about quiet-time "
+                "HR elevation, never measured stress."
+            ),
+        }
+
+    if truncated:
+        return insufficient("hr_or_steps_timeseries_truncated")
+    baseline = resting_baseline(daily_rhr)
+    if baseline is None:
+        return insufficient("resting_hr_baseline_too_thin")
+    if not hr_samples:
+        return insufficient("no_heart_rate_samples")
+    if not step_samples:
+        return insufficient("no_step_samples_for_stillness")
+
+    quiet = quiet_windows(step_samples, workout_spans, day, tz)
+    coverage = quiet_coverage(quiet, hr_samples, day, tz)
+    if not quiet or coverage < MIN_COVERAGE:
+        return insufficient("quiet_window_coverage_too_low")
+
+    hints = arousal_hint_intervals(hr_samples, quiet, baseline["median_bpm"])
+    confidence = "medium" if coverage >= MIN_COVERAGE_FOR_MEDIUM else "low"
+
+    return {
+        "status": STATUS_OK,
+        "confidence": confidence,  # hint-grade: capped at medium by design
+        "coverage": round(coverage, 3),
+        "baseline_bpm": round(baseline["median_bpm"], 1),
+        "baseline_days": baseline["days"],
+        "margin_bpm": AROUSAL_MARGIN_BPM,
+        "intervals": [
+            {
+                "start": hint.start.isoformat(),
+                "end": hint.end.isoformat(),
+                "minutes": round(hint.minutes, 1),
+                "hr_mean": round(hint.hr_mean, 1),
+                "hr_peak": round(hint.hr_peak, 1),
+                "elevation_bpm": round(hint.hr_mean - hint.baseline_bpm, 1),
+                "likely_context": context_for(hint.start, hint.end)
+                + meal_context(hint, meals),
+            }
+            for hint in hints
+        ],
+        "note": (
+            "Quiet-time HR elevation over the personal resting baseline. "
+            "Caffeine, heat, illness, or excitement produce the same signal — "
+            "these are arousal hints, not measured stress, and cannot alone "
+            "justify a plan change."
+        ),
+    }

--- a/healthmes/mcp_server/arousal.py
+++ b/healthmes/mcp_server/arousal.py
@@ -185,6 +185,7 @@ def arousal_hint_intervals(
     """
     threshold = baseline_bpm + AROUSAL_MARGIN_BPM
     min_len = dt.timedelta(minutes=MIN_HINT_MINUTES)
+    dip_gap = dt.timedelta(minutes=HINT_GAP_TOLERANCE_MINUTES)
 
     hints: list[HintInterval] = []
     for window in quiet:
@@ -194,23 +195,35 @@ def arousal_hint_intervals(
             ]
             if not elevated_indices:
                 continue
-            span = chain[elevated_indices[0] : elevated_indices[-1] + 1]
-            start, end = span[0][0], span[-1][0]
-            if end - start < min_len:
-                continue
-            values = [value for _, value in span]
-            mean = sum(values) / len(values)
-            if mean < threshold:
-                continue
-            hints.append(
-                HintInterval(
-                    start=start,
-                    end=end,
-                    hr_mean=mean,
-                    hr_peak=max(values),
-                    baseline_bpm=baseline_bpm,
+            # Group elevated samples that are close in time: a normal-HR
+            # stretch longer than the dip tolerance ENDS a candidate — two
+            # separate elevated runs must never fuse into one long "sustained"
+            # span just because the chain (and its overall mean) allows it.
+            groups: list[list[int]] = [[elevated_indices[0]]]
+            for index in elevated_indices[1:]:
+                previous_at = chain[groups[-1][-1]][0]
+                if chain[index][0] - previous_at <= dip_gap:
+                    groups[-1].append(index)
+                else:
+                    groups.append([index])
+            for group in groups:
+                span = chain[group[0] : group[-1] + 1]
+                start, end = span[0][0], span[-1][0]
+                if end - start < min_len:
+                    continue
+                values = [value for _, value in span]
+                mean = sum(values) / len(values)
+                if mean < threshold:
+                    continue
+                hints.append(
+                    HintInterval(
+                        start=start,
+                        end=end,
+                        hr_mean=mean,
+                        hr_peak=max(values),
+                        baseline_bpm=baseline_bpm,
+                    )
                 )
-            )
     return hints
 
 

--- a/healthmes/mcp_server/arousal.py
+++ b/healthmes/mcp_server/arousal.py
@@ -11,16 +11,18 @@ plan decision on hints alone.
 
 Pipeline (pure functions, no I/O — the MCP layer fetches):
 
-1. ``quiet_windows``  — waking-hour stretches with ~zero steps, outside
-   workout spans. Night hours are excluded as likely sleep (approximation,
+1. ``quiet_windows``  — waking-hour stretches evidenced by **consecutive**
+   still step samples (a lone still bucket proves nothing), with workout
+   spans subtracted, night hours excluded as likely sleep (approximation,
    documented; sleep-event masking is a future refinement — hence the
    confidence cap).
-2. ``resting_baseline`` — median + spread of the last 14 daily resting-HR
-   values (provider-computed RHR; needs ``MIN_BASELINE_DAYS`` to exist).
-3. ``arousal_hint_intervals`` — sustained (≥ ``MIN_HINT_MINUTES``) runs of
-   quiet-window HR at or above baseline + margin.
-4. ``build_arousal_hints`` — the response payload with coverage, capped
-   confidence, and honest ``insufficient_data``.
+2. ``resting_baseline`` — median of the last 14 daily resting-HR values
+   (provider-computed RHR; needs ``MIN_BASELINE_DAYS`` to exist).
+3. ``arousal_hint_intervals`` — per quiet window, sustained elevated spans
+   whose **mean over every sample in the span (dips included)** clears the
+   threshold; data gaps break spans instead of being bridged.
+4. ``build_arousal_hints`` — the response payload with observation-based
+   coverage, capped confidence, and honest ``insufficient_data``.
 
 All thresholds are named constants and are expert-tunable placeholders per
 the PLAN convention — values chosen to be conservative (few false hints)
@@ -35,18 +37,22 @@ from typing import Any
 # Expert-tunable placeholders (PLAN §1.5 confidence-boundary convention).
 QUIET_STEP_THRESHOLD = 5  # steps per sample bucket at or below → "still"
 MIN_QUIET_MINUTES = 15  # a stillness stretch shorter than this is ignored
+MAX_STILL_PAIR_GAP_MINUTES = 15  # consecutive still samples further apart don't chain
 MIN_HINT_MINUTES = 10  # sustained elevation required for one hint
-HINT_GAP_TOLERANCE_MINUTES = 3  # brief dips/missing samples inside a run
+HINT_GAP_TOLERANCE_MINUTES = 3  # max spacing between samples inside one span
 AROUSAL_MARGIN_BPM = 12.0  # elevation over resting baseline that counts
 MIN_BASELINE_DAYS = 7  # fewer RHR days → insufficient_data
 WAKING_START_HOUR = 7  # local; earlier is treated as likely sleep
 WAKING_END_HOUR = 23
+HR_OBSERVATION_SPAN_MINUTES = 6  # one HR sample vouches for at most this span
 MIN_COVERAGE_FOR_MEDIUM = 0.30  # of the waking window observed while quiet
 MIN_COVERAGE = 0.10  # below → insufficient_data
 MEAL_CONTEXT_WINDOW_MINUTES = 45  # food_log entries this close are context
 
 STATUS_OK = "ok"
 STATUS_INSUFFICIENT = "insufficient_data"
+
+Span = tuple[dt.datetime, dt.datetime]
 
 
 @dataclass(frozen=True)
@@ -64,11 +70,11 @@ class HintInterval:
         return (self.end - self.start).total_seconds() / 60.0
 
 
-def _merge_spans(
-    spans: list[tuple[dt.datetime, dt.datetime]],
-) -> list[tuple[dt.datetime, dt.datetime]]:
-    merged: list[tuple[dt.datetime, dt.datetime]] = []
+def _merge_spans(spans: list[Span]) -> list[Span]:
+    merged: list[Span] = []
     for start, end in sorted(spans):
+        if end <= start:
+            continue
         if merged and start <= merged[-1][1]:
             merged[-1] = (merged[-1][0], max(merged[-1][1], end))
         else:
@@ -76,7 +82,24 @@ def _merge_spans(
     return merged
 
 
-def waking_window(day: dt.date, tz: dt.tzinfo) -> tuple[dt.datetime, dt.datetime]:
+def _subtract_spans(spans: list[Span], blocks: list[Span]) -> list[Span]:
+    """``spans`` minus every ``blocks`` overlap (both need not be merged)."""
+    result = list(spans)
+    for b_start, b_end in _merge_spans(list(blocks)):
+        next_result: list[Span] = []
+        for start, end in result:
+            if b_end <= start or end <= b_start:
+                next_result.append((start, end))
+                continue
+            if start < b_start:
+                next_result.append((start, b_start))
+            if b_end < end:
+                next_result.append((b_end, end))
+        result = next_result
+    return [(start, end) for start, end in result if end > start]
+
+
+def waking_window(day: dt.date, tz: dt.tzinfo) -> Span:
     """The local waking span used for coverage and likely-sleep exclusion."""
     return (
         dt.datetime.combine(day, dt.time(WAKING_START_HOUR), tzinfo=tz),
@@ -86,39 +109,37 @@ def waking_window(day: dt.date, tz: dt.tzinfo) -> tuple[dt.datetime, dt.datetime
 
 def quiet_windows(
     step_samples: list[tuple[dt.datetime, float]],
-    workout_spans: list[tuple[dt.datetime, dt.datetime]],
+    workout_spans: list[Span],
     day: dt.date,
     tz: dt.tzinfo,
-) -> list[tuple[dt.datetime, dt.datetime]]:
-    """Waking stretches that are still (≈no steps) and outside workouts.
+) -> list[Span]:
+    """Waking stretches evidenced still, outside workouts.
 
-    Step samples are bucketed observations ``(local_time, steps)``; a gap in
-    step data is NOT treated as stillness — only observed ≤threshold buckets
-    qualify, so missing data lowers coverage instead of inventing quiet.
+    Stillness needs **two consecutive** still samples: a span is added only
+    between adjacent samples that are both ≤ threshold and no further apart
+    than the pairing cap — so gaps in step data are *unknown*, not quiet,
+    and a lone still bucket proves nothing. Workout spans are subtracted
+    from the result (not merely sampled at bucket timestamps), so a workout
+    starting between two buckets still masks its minutes.
     """
     wake_start, wake_end = waking_window(day, tz)
-    workout_merged = _merge_spans(list(workout_spans))
+    pair_gap = dt.timedelta(minutes=MAX_STILL_PAIR_GAP_MINUTES)
 
     ordered = sorted(step_samples)
-    still: list[tuple[dt.datetime, dt.datetime]] = []
-    for index, (at, steps) in enumerate(ordered):
-        if steps > QUIET_STEP_THRESHOLD:
+    still_pairs: list[Span] = []
+    for (at_a, steps_a), (at_b, steps_b) in zip(ordered, ordered[1:]):
+        if steps_a > QUIET_STEP_THRESHOLD or steps_b > QUIET_STEP_THRESHOLD:
             continue
-        if not (wake_start <= at < wake_end):
+        if at_b - at_a > pair_gap:
             continue
-        if any(start <= at < end for start, end in workout_merged):
-            continue
-        # A bucket covers until the next sample (bounded to 15 min so sparse
-        # data cannot claim long stillness).
-        if index + 1 < len(ordered):
-            span_end = min(ordered[index + 1][0], at + dt.timedelta(minutes=15))
-        else:
-            span_end = at + dt.timedelta(minutes=15)
-        still.append((at, min(span_end, wake_end)))
+        start = max(at_a, wake_start)
+        end = min(at_b, wake_end)
+        if end > start:
+            still_pairs.append((start, end))
 
-    merged = _merge_spans(still)
+    quiet = _subtract_spans(_merge_spans(still_pairs), list(workout_spans))
     min_span = dt.timedelta(minutes=MIN_QUIET_MINUTES)
-    return [(start, end) for start, end in merged if end - start >= min_span]
+    return [(start, end) for start, end in quiet if end - start >= min_span]
 
 
 def resting_baseline(daily_rhr: list[tuple[dt.date, float]]) -> dict[str, Any] | None:
@@ -132,79 +153,111 @@ def resting_baseline(daily_rhr: list[tuple[dt.date, float]]) -> dict[str, Any] |
     }
 
 
+def _window_chains(
+    samples: list[tuple[dt.datetime, float]], window: Span
+) -> list[list[tuple[dt.datetime, float]]]:
+    """Contiguous sample chains inside one window (data gaps break chains)."""
+    gap = dt.timedelta(minutes=HINT_GAP_TOLERANCE_MINUTES)
+    inside = [item for item in samples if window[0] <= item[0] < window[1]]
+    chains: list[list[tuple[dt.datetime, float]]] = []
+    for item in inside:
+        if chains and item[0] - chains[-1][-1][0] <= gap:
+            chains[-1].append(item)
+        else:
+            chains.append([item])
+    return chains
+
+
 def arousal_hint_intervals(
     hr_samples: list[tuple[dt.datetime, float]],
-    quiet: list[tuple[dt.datetime, dt.datetime]],
+    quiet: list[Span],
     baseline_bpm: float,
 ) -> list[HintInterval]:
-    """Sustained quiet-time HR runs at or above baseline + margin."""
+    """Sustained quiet-time elevation, judged over every sample in the span.
+
+    Each quiet window is processed independently (hints never bridge
+    windows). Within a window, contiguous sample chains (gaps ≤ tolerance)
+    are scanned for spans running from one above-threshold sample to a later
+    one; a span counts only when it is long enough AND the mean of **all**
+    its samples — dips included — clears the threshold. Interleaved
+    below-threshold readings therefore drag the mean down and kill the hint
+    instead of being silently discarded.
+    """
     threshold = baseline_bpm + AROUSAL_MARGIN_BPM
-    gap = dt.timedelta(minutes=HINT_GAP_TOLERANCE_MINUTES)
     min_len = dt.timedelta(minutes=MIN_HINT_MINUTES)
 
-    in_quiet = [
-        (at, value)
-        for at, value in sorted(hr_samples)
-        if any(start <= at < end for start, end in quiet)
-    ]
-
     hints: list[HintInterval] = []
-    run: list[tuple[dt.datetime, float]] = []
-    for at, value in in_quiet:
-        if value >= threshold:
-            if run and at - run[-1][0] > gap:
-                _flush_run(run, baseline_bpm, min_len, hints)
-                run = []
-            run.append((at, value))
-        elif run and at - run[-1][0] <= gap:
-            continue  # brief dip inside the tolerance window
-        else:
-            _flush_run(run, baseline_bpm, min_len, hints)
-            run = []
-    _flush_run(run, baseline_bpm, min_len, hints)
+    for window in quiet:
+        for chain in _window_chains(sorted(hr_samples), window):
+            elevated_indices = [
+                index for index, (_, value) in enumerate(chain) if value >= threshold
+            ]
+            if not elevated_indices:
+                continue
+            span = chain[elevated_indices[0] : elevated_indices[-1] + 1]
+            start, end = span[0][0], span[-1][0]
+            if end - start < min_len:
+                continue
+            values = [value for _, value in span]
+            mean = sum(values) / len(values)
+            if mean < threshold:
+                continue
+            hints.append(
+                HintInterval(
+                    start=start,
+                    end=end,
+                    hr_mean=mean,
+                    hr_peak=max(values),
+                    baseline_bpm=baseline_bpm,
+                )
+            )
     return hints
 
 
-def _flush_run(
-    run: list[tuple[dt.datetime, float]],
-    baseline_bpm: float,
-    min_len: dt.timedelta,
-    out: list[HintInterval],
-) -> None:
-    if len(run) < 2:
-        return
-    start, end = run[0][0], run[-1][0]
-    if end - start < min_len:
-        return
-    values = [value for _, value in run]
-    out.append(
-        HintInterval(
-            start=start,
-            end=end,
-            hr_mean=sum(values) / len(values),
-            hr_peak=max(values),
-            baseline_bpm=baseline_bpm,
-        )
-    )
+def observation_spans(
+    hr_samples: list[tuple[dt.datetime, float]],
+) -> list[Span]:
+    """Spans genuinely vouched for by HR samples.
+
+    Each sample covers until the next one, bounded by the expected cadence —
+    so five samples in twelve minutes cover ~twelve minutes, never a whole
+    afternoon, and internal gaps stay uncovered.
+    """
+    bound = dt.timedelta(minutes=HR_OBSERVATION_SPAN_MINUTES)
+    ordered = sorted(at for at, _ in hr_samples)
+    spans: list[Span] = []
+    for index, at in enumerate(ordered):
+        if index + 1 < len(ordered):
+            end = min(ordered[index + 1], at + bound)
+        else:
+            end = at + bound
+        spans.append((at, end))
+    return _merge_spans(spans)
+
+
+def _intersect(a: list[Span], b: list[Span]) -> list[Span]:
+    out: list[Span] = []
+    for a_start, a_end in a:
+        for b_start, b_end in b:
+            start, end = max(a_start, b_start), min(a_end, b_end)
+            if end > start:
+                out.append((start, end))
+    return _merge_spans(out)
 
 
 def quiet_coverage(
-    quiet: list[tuple[dt.datetime, dt.datetime]],
+    quiet: list[Span],
     hr_samples: list[tuple[dt.datetime, float]],
     day: dt.date,
     tz: dt.tzinfo,
 ) -> float:
-    """Fraction of the waking window that is quiet AND has HR observations."""
+    """Fraction of the waking window both quiet AND actually HR-observed."""
     wake_start, wake_end = waking_window(day, tz)
     waking_seconds = (wake_end - wake_start).total_seconds()
     if waking_seconds <= 0:
         return 0.0
-    hr_times = sorted(at for at, _ in hr_samples)
-    covered = 0.0
-    for start, end in quiet:
-        inside = [at for at in hr_times if start <= at < end]
-        if len(inside) >= 2:
-            covered += (min(end, inside[-1] + dt.timedelta(minutes=5)) - start).total_seconds()
+    observed = _intersect(quiet, observation_spans(hr_samples))
+    covered = sum((end - start).total_seconds() for start, end in observed)
     return max(0.0, min(1.0, covered / waking_seconds))
 
 
@@ -226,7 +279,7 @@ def build_arousal_hints(
     tz: dt.tzinfo,
     hr_samples: list[tuple[dt.datetime, float]],
     step_samples: list[tuple[dt.datetime, float]],
-    workout_spans: list[tuple[dt.datetime, dt.datetime]],
+    workout_spans: list[Span],
     daily_rhr: list[tuple[dt.date, float]],
     truncated: bool,
     context_for: Any,

--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -1201,7 +1201,8 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
     day-level proxy (native daily stress score, else 100 - the night-HRV
     resilience score) spread over morning/afternoon/evening sections — the
     proxy has no intraday resolution, so treat within-day differences as
-    context, not measurement. Non-Garmin responses additionally carry
+    context, not measurement. Responses without a usable Garmin intraday
+    series (the daily-score/proxy/insufficient paths) additionally carry
     `arousal_hints`: deterministic quiet-time HR-elevation intervals over the
     personal resting baseline (hint-grade, confidence capped at medium —
     physiological arousal, never measured stress; see healthmes/mcp_server/

--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -1016,17 +1016,27 @@ def _stress_samples(rows: Iterable[Mapping[str, Any]]) -> list[tuple[dt.datetime
 
 
 def _typed_samples(
-    rows: Iterable[Mapping[str, Any]], series_type: str
+    rows: Iterable[Mapping[str, Any]],
+    series_type: str,
+    *,
+    drop_nonpositive: bool = False,
 ) -> list[tuple[dt.datetime, float]]:
-    """(aware UTC timestamp, value) samples of one series type; non-positive
-    values dropped (HR of 0 is a sensor gap, steps of 0 are kept via >= 0)."""
+    """(aware UTC timestamp, value) samples of one series type.
+
+    Negative values are always dropped; ``drop_nonpositive`` additionally
+    drops zeros (an HR of 0 is a sensor gap, while 0 steps is stillness
+    evidence that must be kept).
+    """
     samples: list[tuple[dt.datetime, float]] = []
+    floor = 0.0 if drop_nonpositive else -0.0
     for row in rows:
         if row.get("type") != series_type:
             continue
         recorded_at = _parse_recorded_at(row.get("timestamp"))
         value = _as_float(row.get("value"))
         if recorded_at is None or value is None or value < 0:
+            continue
+        if drop_nonpositive and value <= floor:
             continue
         samples.append((recorded_at, value))
     return samples
@@ -1049,19 +1059,43 @@ async def _arousal_hints_for(
     stress-timeline response never fails because hints could not be built.
     """
     try:
-        series_rows, truncated = await client.collect_timeseries_tracked(
+        # One fetch per series: a full day of 1-minute HR alone is ~1,440
+        # rows, so a combined fetch would trip the shared page cap and
+        # spuriously truncate (review finding). The vendor range query can
+        # widen end bounds to midnight, so samples are re-filtered to the
+        # local-day UTC window below.
+        hr_rows, hr_truncated = await client.collect_timeseries_tracked(
             user_id,
             start_utc.isoformat(),
             end_utc.isoformat(),
-            [HR_SERIES_TYPE, STEPS_SERIES_TYPE],
+            [HR_SERIES_TYPE],
         )
-        hr_utc = _typed_samples(series_rows, HR_SERIES_TYPE)
-        steps_utc = _typed_samples(series_rows, STEPS_SERIES_TYPE)
+        step_rows, steps_truncated = await client.collect_timeseries_tracked(
+            user_id,
+            start_utc.isoformat(),
+            end_utc.isoformat(),
+            [STEPS_SERIES_TYPE],
+        )
+        truncated = hr_truncated or steps_truncated
+        hr_utc = [
+            (at, value)
+            for at, value in _typed_samples(hr_rows, HR_SERIES_TYPE, drop_nonpositive=True)
+            if start_utc <= at < end_utc
+        ]
+        steps_utc = [
+            (at, value)
+            for at, value in _typed_samples(step_rows, STEPS_SERIES_TYPE)
+            if start_utc <= at < end_utc
+        ]
 
+        # The vendor returns only workouts fully contained in the queried
+        # range (event_record_repository), and date-only bounds are read as
+        # UTC midnights — pad generously so evening workouts in any timezone
+        # are included; extra spans only ever mask more, never fabricate.
         workout_rows = await client.collect_workouts(
             user_id,
             (day - dt.timedelta(days=1)).isoformat(),
-            (day + dt.timedelta(days=1)).isoformat(),
+            (day + dt.timedelta(days=2)).isoformat(),
         )
         workout_spans: list[tuple[dt.datetime, dt.datetime]] = []
         for row in workout_rows:
@@ -1081,7 +1115,7 @@ async def _arousal_hints_for(
         rhr_series = interpret.summary_daily_values(
             rhr_rows, "resting_heart_rate_bpm", day
         )
-    except OWClientError as exc:
+    except (OWClientError, httpx.HTTPError) as exc:
         logging.getLogger(__name__).warning(
             "arousal hints: open-wearables fetch failed: %s", exc
         )

--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -42,6 +42,7 @@ resolved by :func:`_local_timezone` (override -> settings -> env -> system).
 import asyncio
 import datetime as dt
 import functools
+import logging
 import os
 import re
 import uuid
@@ -57,7 +58,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from healthmes.config import Settings, get_settings, system_timezone
-from healthmes.mcp_server import impact, interpret, timeline
+from healthmes.mcp_server import arousal, impact, interpret, timeline
 from healthmes.mcp_server.ow_client import OWClient, OWClientError, resolve_single_user_id
 from healthmes.store import (
     AppUsageSample,
@@ -873,6 +874,8 @@ async def get_personal_baselines(
 # The vendor series type carrying intraday stress (schemas/enums/series_types.py;
 # Garmin is the only provider that ships one — docs/PLAN.md 1.5).
 STRESS_SERIES_TYPE = "garmin_stress_level"
+HR_SERIES_TYPE = "heart_rate"
+STEPS_SERIES_TYPE = "steps"
 
 # Component terms sourced from open-wearables health data; how many of them a
 # forecast window carries grades the forecast's evidence richness.
@@ -1012,6 +1015,143 @@ def _stress_samples(rows: Iterable[Mapping[str, Any]]) -> list[tuple[dt.datetime
     return samples
 
 
+def _typed_samples(
+    rows: Iterable[Mapping[str, Any]], series_type: str
+) -> list[tuple[dt.datetime, float]]:
+    """(aware UTC timestamp, value) samples of one series type; non-positive
+    values dropped (HR of 0 is a sensor gap, steps of 0 are kept via >= 0)."""
+    samples: list[tuple[dt.datetime, float]] = []
+    for row in rows:
+        if row.get("type") != series_type:
+            continue
+        recorded_at = _parse_recorded_at(row.get("timestamp"))
+        value = _as_float(row.get("value"))
+        if recorded_at is None or value is None or value < 0:
+            continue
+        samples.append((recorded_at, value))
+    return samples
+
+
+async def _arousal_hints_for(
+    client: OWClient,
+    user_id: str,
+    day: dt.date,
+    tz: dt.tzinfo,
+    start_utc: dt.datetime,
+    end_utc: dt.datetime,
+) -> dict[str, Any]:
+    """The ``arousal_hints`` payload for non-Garmin days (healthmes/mcp_server/arousal.py).
+
+    Interpretation stays deterministic code: this fetches continuous HR +
+    steps + workouts + the 14-day resting-HR baseline and the day's
+    calendar/app/meal rows, then delegates to the pure pipeline. Any fetch
+    failure degrades to an honest ``insufficient_data`` payload — the parent
+    stress-timeline response never fails because hints could not be built.
+    """
+    try:
+        series_rows, truncated = await client.collect_timeseries_tracked(
+            user_id,
+            start_utc.isoformat(),
+            end_utc.isoformat(),
+            [HR_SERIES_TYPE, STEPS_SERIES_TYPE],
+        )
+        hr_utc = _typed_samples(series_rows, HR_SERIES_TYPE)
+        steps_utc = _typed_samples(series_rows, STEPS_SERIES_TYPE)
+
+        workout_rows = await client.collect_workouts(
+            user_id,
+            (day - dt.timedelta(days=1)).isoformat(),
+            (day + dt.timedelta(days=1)).isoformat(),
+        )
+        workout_spans: list[tuple[dt.datetime, dt.datetime]] = []
+        for row in workout_rows:
+            w_start = _parse_recorded_at(row.get("start_time"))
+            w_end = _parse_recorded_at(row.get("end_time"))
+            if w_start is None:
+                continue
+            if w_end is None or w_end <= w_start:
+                w_end = w_start + dt.timedelta(hours=1)
+            workout_spans.append((w_start.astimezone(tz), w_end.astimezone(tz)))
+
+        rhr_rows = await client.collect_recovery_summaries(
+            user_id,
+            (day - dt.timedelta(days=interpret.BASELINE_WINDOW_DAYS)).isoformat(),
+            day.isoformat(),
+        )
+        rhr_series = interpret.summary_daily_values(
+            rhr_rows, "resting_heart_rate_bpm", day
+        )
+    except OWClientError as exc:
+        logging.getLogger(__name__).warning(
+            "arousal hints: open-wearables fetch failed: %s", exc
+        )
+        return {
+            "status": arousal.STATUS_INSUFFICIENT,
+            "reason": "wearable_fetch_failed",
+            "confidence": "low",
+            "coverage": 0.0,
+            "intervals": [],
+        }
+
+    with _store_session() as session:
+        event_rows = session.scalars(
+            select(CalendarEventMirror)
+            .where(
+                CalendarEventMirror.start_at < end_utc,
+                CalendarEventMirror.end_at > start_utc,
+            )
+            .order_by(CalendarEventMirror.start_at)
+        ).all()
+        usage_rows = session.scalars(
+            select(AppUsageSample)
+            .where(
+                AppUsageSample.bucket_start >= start_utc - dt.timedelta(minutes=60),
+                AppUsageSample.bucket_start < end_utc,
+            )
+            .order_by(AppUsageSample.bucket_start)
+        ).all()
+        meal_rows = session.scalars(
+            select(FoodLog)
+            .where(FoodLog.logged_at >= start_utc, FoodLog.logged_at < end_utc)
+            .order_by(FoodLog.logged_at)
+        ).all()
+        events = [
+            (
+                _ensure_utc_dt(row.start_at).astimezone(tz),
+                _ensure_utc_dt(row.end_at).astimezone(tz),
+                row.summary,
+            )
+            for row in event_rows
+        ]
+        usage = [
+            (
+                _ensure_utc_dt(row.bucket_start).astimezone(tz),
+                row.category,
+                row.foreground_seconds,
+            )
+            for row in usage_rows
+        ]
+        meals = [
+            (
+                _ensure_utc_dt(row.logged_at).astimezone(tz),
+                str(row.description or "meal")[:60],
+            )
+            for row in meal_rows
+        ]
+
+    return arousal.build_arousal_hints(
+        day=day,
+        tz=tz,
+        hr_samples=[(at.astimezone(tz), value) for at, value in hr_utc],
+        step_samples=[(at.astimezone(tz), value) for at, value in steps_utc],
+        workout_spans=workout_spans,
+        daily_rhr=sorted(rhr_series.items()),
+        truncated=truncated,
+        context_for=lambda start, end: timeline.attach_context(start, end, events, usage),
+        meals=meals,
+    )
+
+
 @mcp.tool
 @_with_ow_errors
 async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
@@ -1027,8 +1167,12 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
     day-level proxy (native daily stress score, else 100 - the night-HRV
     resilience score) spread over morning/afternoon/evening sections — the
     proxy has no intraday resolution, so treat within-day differences as
-    context, not measurement. `date` is ISO YYYY-MM-DD (default today,
-    local). Honest `insufficient_data` when no stress signal exists at all.
+    context, not measurement. Non-Garmin responses additionally carry
+    `arousal_hints`: deterministic quiet-time HR-elevation intervals over the
+    personal resting baseline (hint-grade, confidence capped at medium —
+    physiological arousal, never measured stress; see healthmes/mcp_server/
+    arousal.py). `date` is ISO YYYY-MM-DD (default today, local). Honest
+    `insufficient_data` when no stress signal exists at all.
     """
     tz = _local_timezone()
     day = _parse_date_local(date, "date", tz)
@@ -1054,6 +1198,9 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
             "confidence": "low",
             "truncated": False,
             "intervals": [],
+            "arousal_hints": await _arousal_hints_for(
+                client, user_id, day, tz, start_utc, end_utc
+            ),
         }
     if series_truncated and not samples_utc:
         return {
@@ -1065,6 +1212,9 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
             "coverage": 0.0,
             "truncated": True,
             "intervals": [],
+            "arousal_hints": await _arousal_hints_for(
+                client, user_id, day, tz, start_utc, end_utc
+            ),
         }
 
     day_level: dict[str, Any] | None = None
@@ -1101,6 +1251,9 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
                 "confidence": "low",
                 "truncated": False,
                 "intervals": [],
+                "arousal_hints": await _arousal_hints_for(
+                    client, user_id, day, tz, start_utc, end_utc
+                ),
             }
         intervals = timeline.proxy_sections(day, tz, float(context["value"]))
         source = (
@@ -1173,6 +1326,12 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
         response["status"] = interpret.STATUS_INSUFFICIENT
         response["reason"] = "stress_timeseries_truncated"
         response["confidence"] = "low"
+    if source != "garmin_stress_timeseries":
+        # Non-Garmin days have no measured intraday stress; attach the
+        # deterministic HR arousal-hint interpretation (PLAN §13 follow-up).
+        response["arousal_hints"] = await _arousal_hints_for(
+            client, user_id, day, tz, start_utc, end_utc
+        )
     return response
 
 

--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -1361,9 +1361,11 @@ async def get_stress_timeline(date: str | None = None) -> dict[str, Any]:
         response["status"] = interpret.STATUS_INSUFFICIENT
         response["reason"] = "stress_timeseries_truncated"
         response["confidence"] = "low"
-    if source != "garmin_stress_timeseries":
-        # Non-Garmin days have no measured intraday stress; attach the
-        # deterministic HR arousal-hint interpretation (PLAN §13 follow-up).
+    if source != "garmin_stress_timeseries" or series_truncated:
+        # No *usable* Garmin intraday series (non-Garmin day, daily/proxy
+        # fallback, or a truncated series the skill must not lean on):
+        # attach the deterministic HR arousal-hint interpretation
+        # (PLAN §13 follow-up).
         response["arousal_hints"] = await _arousal_hints_for(
             client, user_id, day, tz, start_utc, end_utc
         )

--- a/skills/healthmes-stress/SKILL.md
+++ b/skills/healthmes-stress/SKILL.md
@@ -70,9 +70,11 @@ interval or score.
   data cannot support a definite plan decision; a definite decision requires
   `observed_on` to match the target date and `stale_days: 0`.
 
-### `arousal_hints` (response field, non-Garmin days)
+### `arousal_hints` (response field — days without a usable Garmin intraday series)
 
-- Non-Garmin responses may carry an `arousal_hints` field: deterministic
+- Any response whose `source` is not `garmin_stress_timeseries` (including
+  `garmin_daily_stress_score`, the resilience proxy, and insufficient-data
+  responses) may carry an `arousal_hints` field: deterministic
   quiet-time heart-rate elevation intervals over the personal resting
   baseline, with calendar, app, and meal-log overlap as `likely_context`.
 - These are **hints about physiological arousal, never measured stress**.

--- a/skills/healthmes-stress/SKILL.md
+++ b/skills/healthmes-stress/SKILL.md
@@ -70,6 +70,23 @@ interval or score.
   data cannot support a definite plan decision; a definite decision requires
   `observed_on` to match the target date and `stale_days: 0`.
 
+### `arousal_hints` (response field, non-Garmin days)
+
+- Non-Garmin responses may carry an `arousal_hints` field: deterministic
+  quiet-time heart-rate elevation intervals over the personal resting
+  baseline, with calendar, app, and meal-log overlap as `likely_context`.
+- These are **hints about physiological arousal, never measured stress**.
+  Caffeine, heat, illness, or excitement produce the same signal. Say
+  "elevated heart rate while at rest" or "arousal hint"; never present a
+  hint as stress, and never present its context as a cause.
+- Use hints only to (a) answer "when" questions at hint strength — state
+  plainly that this is a heart-rate hint, not a stress measurement — and
+  (b) corroborate day-level evidence. A hint can never be the deciding
+  evidence for `reconsider` on its own.
+- Honor the field's own `status`, `coverage`, and `confidence` (capped at
+  `medium` by design). When `status` is `insufficient_data`, do not mention
+  intraday timing at all.
+
 For an unknown source, absent source, `status: insufficient_data`,
 `truncated: true`, or `confidence: low`, return `insufficient_data`.
 

--- a/tests/mcp_server/test_arousal.py
+++ b/tests/mcp_server/test_arousal.py
@@ -1,0 +1,159 @@
+"""HR arousal-hint interpretation pipeline (healthmes/mcp_server/arousal.py).
+
+Deterministic synthetic-day fixtures: a quiet afternoon with elevated HR must
+produce exactly one hint; movement, workouts, night hours, thin baselines,
+and sparse coverage must all degrade honestly instead of inventing hints.
+"""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+from healthmes.mcp_server import arousal
+
+TZ = ZoneInfo("Asia/Seoul")
+DAY = dt.date(2026, 7, 20)
+
+
+def _t(hour: int, minute: int = 0) -> dt.datetime:
+    return dt.datetime.combine(DAY, dt.time(hour, minute), tzinfo=TZ)
+
+
+def _steps_still(start_h: int, end_h: int, every_min: int = 5):
+    """Zero-step buckets across [start_h, end_h)."""
+    out = []
+    at = _t(start_h)
+    while at < _t(end_h):
+        out.append((at, 0.0))
+        at += dt.timedelta(minutes=every_min)
+    return out
+
+
+def _hr_flat(start_h: int, end_h: int, bpm: float, every_min: int = 2):
+    out = []
+    at = _t(start_h)
+    while at < _t(end_h):
+        out.append((at, bpm))
+        at += dt.timedelta(minutes=every_min)
+    return out
+
+
+RHR_14D = [(DAY - dt.timedelta(days=i), 58.0) for i in range(1, 15)]
+
+
+def _build(hr, steps, workouts=(), rhr=RHR_14D, truncated=False, meals=()):
+    return arousal.build_arousal_hints(
+        day=DAY,
+        tz=TZ,
+        hr_samples=hr,
+        step_samples=steps,
+        workout_spans=list(workouts),
+        daily_rhr=rhr,
+        truncated=truncated,
+        context_for=lambda start, end: [],
+        meals=list(meals),
+    )
+
+
+# --- happy path --------------------------------------------------------------
+
+
+def test_sustained_quiet_elevation_yields_one_hint():
+    # Quiet 13-17h; HR 60 except a 14:00-14:30 stretch at 74 (58+12=70 threshold).
+    hr = _hr_flat(13, 14, 60.0) + _hr_flat(14, 15, 74.0) + _hr_flat(15, 17, 61.0)
+    payload = _build(hr, _steps_still(13, 17))
+
+    assert payload["status"] == "ok"
+    assert payload["baseline_bpm"] == 58.0
+    assert len(payload["intervals"]) == 1
+    hint = payload["intervals"][0]
+    assert hint["minutes"] >= arousal.MIN_HINT_MINUTES
+    assert hint["hr_peak"] == 74.0
+    assert hint["elevation_bpm"] == 16.0
+    assert "14:00" in hint["start"]
+
+
+def test_brief_spike_below_min_duration_is_ignored():
+    hr = _hr_flat(13, 17, 60.0)
+    # 6-minute spike only (min is 10)
+    hr += [(_t(14, m), 75.0) for m in range(0, 6, 2)]
+    payload = _build(sorted(hr), _steps_still(13, 17))
+    assert payload["status"] == "ok"
+    assert payload["intervals"] == []
+
+
+def test_meal_log_appears_as_context():
+    hr = _hr_flat(14, 15, 75.0) + _hr_flat(13, 14, 60.0) + _hr_flat(15, 17, 60.0)
+    payload = _build(
+        sorted(hr),
+        _steps_still(13, 17),
+        meals=[(_t(13, 40), "아이스 아메리카노")],
+    )
+    [hint] = payload["intervals"]
+    assert any("아메리카노" in c for c in hint["likely_context"])
+
+
+# --- honest degradation ------------------------------------------------------
+
+
+def test_movement_disqualifies_windows():
+    # Same elevated HR but the user was walking: steps > threshold everywhere.
+    hr = _hr_flat(13, 17, 80.0)
+    steps = [(at, 120.0) for at, _ in _steps_still(13, 17)]
+    payload = _build(hr, steps)
+    assert payload["status"] == "insufficient_data"
+    assert payload["reason"] == "quiet_window_coverage_too_low"
+
+
+def test_workout_span_is_masked():
+    hr = _hr_flat(13, 17, 80.0)
+    payload = _build(
+        hr, _steps_still(13, 17), workouts=[(_t(12, 30), _t(17, 30))]
+    )
+    assert payload["status"] == "insufficient_data"
+
+
+def test_night_hours_are_excluded_as_likely_sleep():
+    # Elevated quiet HR at 3am must not produce a daytime hint.
+    hr = [(dt.datetime.combine(DAY, dt.time(3, m), tzinfo=TZ), 80.0) for m in range(0, 59, 2)]
+    steps = [(dt.datetime.combine(DAY, dt.time(3, m), tzinfo=TZ), 0.0) for m in range(0, 59, 5)]
+    payload = _build(hr, steps)
+    assert payload["status"] == "insufficient_data"
+
+
+def test_thin_rhr_baseline_refuses():
+    hr = _hr_flat(13, 17, 75.0)
+    payload = _build(hr, _steps_still(13, 17), rhr=RHR_14D[:3])
+    assert payload["status"] == "insufficient_data"
+    assert payload["reason"] == "resting_hr_baseline_too_thin"
+
+
+def test_truncated_series_refuses():
+    payload = _build(_hr_flat(13, 17, 60.0), _steps_still(13, 17), truncated=True)
+    assert payload["status"] == "insufficient_data"
+    assert payload["reason"] == "hr_or_steps_timeseries_truncated"
+
+
+def test_no_hr_refuses():
+    payload = _build([], _steps_still(13, 17))
+    assert payload["status"] == "insufficient_data"
+
+
+def test_confidence_capped_at_medium_and_low_when_sparse():
+    # Coverage 13-17h quiet out of 7-23h waking ≈ 0.25 → low
+    hr = _hr_flat(13, 17, 60.0)
+    payload = _build(hr, _steps_still(13, 17))
+    assert payload["status"] == "ok"
+    assert payload["confidence"] == "low"
+    # Broad quiet coverage (8-22h) → medium, never high
+    hr_all = _hr_flat(8, 22, 60.0)
+    payload2 = _build(hr_all, _steps_still(8, 22))
+    assert payload2["confidence"] == "medium"
+
+
+def test_step_gaps_do_not_invent_stillness():
+    # Only two step samples 4h apart: bucket coverage is bounded to 15min each,
+    # so quiet coverage stays below the floor.
+    hr = _hr_flat(13, 17, 60.0)
+    steps = [(_t(13), 0.0), (_t(17), 0.0)]
+    payload = _build(hr, steps)
+    assert payload["status"] == "insufficient_data"

--- a/tests/mcp_server/test_arousal.py
+++ b/tests/mcp_server/test_arousal.py
@@ -157,3 +157,57 @@ def test_step_gaps_do_not_invent_stillness():
     steps = [(_t(13), 0.0), (_t(17), 0.0)]
     payload = _build(hr, steps)
     assert payload["status"] == "insufficient_data"
+
+
+# --- adversarial cases from independent review -------------------------------
+
+
+def test_interleaved_dips_drag_mean_below_threshold():
+    # 72bpm highs interleaved with 55bpm dips: old logic discarded dips and
+    # fabricated a "sustained 72" hint; the mean over ALL samples (61.5 < 70)
+    # must kill it.
+    hr = []
+    for m in range(0, 26, 2):
+        hr.append((_t(14, m), 72.0 if (m // 2) % 2 == 0 else 55.0))
+    hr += _hr_flat(13, 14, 60.0) + _hr_flat(15, 17, 60.0)
+    payload = _build(sorted(hr), _steps_still(13, 17))
+    assert payload["status"] == "ok"
+    assert payload["intervals"] == []
+
+
+def test_sparse_evening_samples_cannot_claim_full_coverage():
+    # Five HR samples in 22:47–22:55 only: observation spans are bounded, so
+    # coverage over the 16h waking window must be tiny, not 1.0.
+    hr = [(_t(22, m), 60.0) for m in (47, 49, 51, 53, 55)]
+    payload = _build(hr, _steps_still(7, 23))
+    assert payload["status"] == "insufficient_data"
+    assert payload["reason"] == "quiet_window_coverage_too_low"
+
+
+def test_workout_starting_between_buckets_still_masks():
+    # Still pair at 10:00/10:05 with a workout starting 10:01: the workout
+    # span must be subtracted from the window, not sampled at bucket times.
+    steps = [(_t(10, 0), 0.0), (_t(10, 5), 0.0), (_t(10, 10), 0.0), (_t(10, 15), 0.0)]
+    hr = [(_t(10, m), 90.0) for m in range(0, 16, 2)]
+    payload = _build(hr, steps, workouts=[(_t(10, 1), _t(11, 0))])
+    assert payload["status"] == "insufficient_data"
+
+
+def test_single_isolated_still_sample_proves_nothing():
+    from healthmes.mcp_server.arousal import quiet_windows
+
+    windows = quiet_windows([(_t(13), 0.0)], [], DAY, TZ)
+    assert windows == []
+
+
+def test_hints_never_bridge_across_quiet_windows():
+    # Movement at 13:20 splits stillness into two windows; elevated HR across
+    # the whole stretch must yield per-window hints, never one spanning 13:20.
+    steps = _steps_still(13, 17)
+    steps = [(at, 200.0 if at == _t(13, 20) else v) for at, v in steps]
+    hr = _hr_flat(13, 17, 75.0)
+    payload = _build(hr, steps)
+    assert payload["status"] == "ok"
+    for hint in payload["intervals"]:
+        crosses = hint["start"] < _t(13, 20).isoformat() < hint["end"]
+        assert not crosses

--- a/tests/mcp_server/test_arousal.py
+++ b/tests/mcp_server/test_arousal.py
@@ -211,3 +211,28 @@ def test_hints_never_bridge_across_quiet_windows():
     for hint in payload["intervals"]:
         crosses = hint["start"] < _t(13, 20).isoformat() < hint["end"]
         assert not crosses
+
+
+def test_separated_elevated_runs_never_fuse():
+    # Two 12-min elevated runs (85bpm) separated by 20 min of normal HR:
+    # verification round reproduced one false 40+min "sustained" hint because
+    # the chain-wide mean stayed above threshold. Runs must stay separate.
+    hr = _hr_flat(13, 17, 60.0)
+    hr += [(_t(14, m), 85.0) for m in range(0, 13, 2)]
+    hr += [(_t(14, 32 + m), 85.0) for m in range(0, 13, 2)]
+    payload = _build(sorted(hr), _steps_still(13, 17))
+    assert payload["status"] == "ok"
+    assert len(payload["intervals"]) == 2
+    for hint in payload["intervals"]:
+        assert hint["minutes"] <= 15
+
+
+def test_legitimate_run_not_suppressed_by_later_normal_stretch():
+    # Inverse of fusing: one clean 12-min run must survive even though the
+    # rest of the afternoon is normal (chain-wide mean would be below
+    # threshold if the whole chain were judged together).
+    hr = _hr_flat(13, 17, 60.0) + [(_t(15, m), 85.0) for m in range(0, 13, 2)]
+    payload = _build(sorted(hr), _steps_still(13, 17))
+    assert payload["status"] == "ok"
+    assert len(payload["intervals"]) == 1
+    assert payload["intervals"][0]["hr_peak"] == 85.0


### PR DESCRIPTION
## 무엇

애플워치 등 비-가민 기기의 **낮 시간대** 공백을 채우는 결정론적 해석 모듈. 연속 심박 raw + 걸음 정지 증거 + 운동 마스킹 + 개인 14일 안정심박 baseline으로 '조용한데 심박이 높았던 구간'을 **각성 힌트**로 산출, `get_stress_timeline` 응답에 `arousal_hints` 필드로 부착(가민 실측이 없거나 잘린 날만). 캘린더·앱사용·**식사 기록** 겹침을 likely_context로 조인 — 전부 수동(passive) 데이터, 사용자 손 입력 0 (소유자 결정).

- Layer B: `healthmes/mcp_server/arousal.py` 순수 파이프라인 + server 배선 (비-가민 전 경로, insufficient 응답 포함)
- Layer C: healthmes-stress 스킬에 힌트 능력 규칙 (힌트 언어 강제, 단독 판단 금지, 카페인 등 교란 명시)

## 검증

- 독립 리뷰(gpt-5.6-sol xhigh) **3라운드**: 결함 10건(P1 6) 발견→전부 수정 — 지속상승 조작(딥 평균 포함·런 그룹핑), 커버리지 과대산정, 정지 조작·운동 누출, UTC 경계 운동 누락, **결합 페치 페이지캡 초과로 실데이터에서 전멸하던 문제**, 예외 누출, 계약 문구 3건
- 파이프라인 테스트 18개(리뷰 재현 대항 케이스 7개 포함), 전체 스위트 **1,081 통과**

🤖 Generated with [Claude Code](https://claude.com/claude-code)