### PR TITLE
feat: bound caffeine proposals to explicit personal evidence

### DIFF
--- a/docs/design/CAFFEINE-PROPOSAL-SAFETY.md
+++ b/docs/design/CAFFEINE-PROPOSAL-SAFETY.md
@@ -1,0 +1,66 @@
+# Caffeine proposal safety contract
+
+The caffeine decision function produces a bounded preparation proposal. It does
+not determine a safe dose, prescribe caffeine, or provide medical advice.
+
+## Inputs stay distinct
+
+- `population_daily_guardrail` is a sourced population reference.
+- `personal_daily_limit` is a user-provided ceiling, not a medically validated
+  allowance.
+- `single_dose_guardrail` independently caps one proposal.
+- `personal_event_baseline` is the user's previously confirmed amount for the
+  exact target event. An exact suggestion requires the event ID, source key,
+  aware confirmation time, and current freshness.
+- `consumed_today_mg` must represent complete verified intake from drinks,
+  food, supplements, and medications.
+
+The deterministic bounds are:
+
+```text
+daily_remaining_mg =
+  max(0, min(population_daily_guardrail_mg, personal_daily_limit_mg)
+         - verified_total_consumed_today_mg)
+
+maximum_additional_mg =
+  min(single_dose_guardrail_mg, daily_remaining_mg)
+```
+
+An exact `suggested_additional_mg` is the smaller of that maximum and the
+current event-bound baseline. Without that baseline, the result may expose only
+the upper bound.
+
+## Fail-closed boundaries
+
+The function returns `insufficient_data` or a noop with no numeric
+recommendation instead of an exact suggestion when required evidence is missing, stale, contradictory, or
+outside the supported path. This includes incomplete intake, missing timing,
+unconfirmed adult population status, declared contraindications, sleep-cutoff
+conflicts, and pure powder or highly concentrated caffeine products.
+
+Short sleep can suppress a proposal but never increases it. The function does
+not infer that caffeine caused a sleep outcome. A `0 mg` noop and an
+`insufficient_data` result are normal successful outcomes.
+
+The function is pure: it does not query providers, mutate Calendar, create an
+approval object, or depend on current time. Provider adapters and user-facing
+delivery belong to later integration issues.
+
+Numeric suppression applies to the recommendation fields. The separate facts
+object retains supplied evidence and bounds so callers can explain why a
+proposal was suppressed; delivery adapters must apply their own privacy rules
+before rendering or logging those facts.
+
+## Evidence behind the guardrails
+
+The product treats these references as population-level constraints, not
+individual recommendations:
+
+- [FDA overview for caffeine and most adults](https://www.fda.gov/consumers/consumer-updates/spilling-beans-how-much-caffeine-too-much)
+- [EFSA caffeine assessment](https://www.efsa.europa.eu/en/topics/topic/caffeine)
+- [ACOG guidance for pregnancy](https://www.acog.org/clinical/clinical-guidance/committee-opinion/articles/2010/08/moderate-caffeine-consumption-during-pregnancy)
+- [FDA warning on pure and highly concentrated caffeine](https://www.fda.gov/food/information-select-dietary-supplement-ingredients-and-other-substances/fda-warns-consumers-about-pure-and-highly-concentrated-caffeine)
+- [Drake et al. on caffeine timing and sleep](https://pmc.ncbi.nlm.nih.gov/articles/PMC3805807/)
+
+See [issue #82](https://github.com/NomaDamas/healthmes-agent/issues/82) for
+the acceptance criteria and research discussion that established this contract.

--- a/docs/design/CAFFEINE-PROPOSAL-SAFETY.md
+++ b/docs/design/CAFFEINE-PROPOSAL-SAFETY.md
@@ -10,10 +10,14 @@ not determine a safe dose, prescribe caffeine, or provide medical advice.
   allowance.
 - `single_dose_guardrail` independently caps one proposal.
 - `personal_event_baseline` is the user's previously confirmed amount for the
-  exact target event. An exact suggestion requires the event ID, source key,
-  aware confirmation time, and current freshness.
+  exact target event. The event ID is the binding key; the non-empty source key
+  is opaque provenance retained for audit. An exact suggestion requires both,
+  plus an aware confirmation time and current freshness.
 - `consumed_today_mg` must represent complete verified intake from drinks,
   food, supplements, and medications.
+- `sleep.local_date` and `timing.intended_consumption_at` must use the same
+  user-local day convention. Adapters normalize both before calling the pure
+  function; a mismatch fails closed as stale sleep.
 
 The deterministic bounds are:
 

--- a/healthmes/mcp_server/caffeine.py
+++ b/healthmes/mcp_server/caffeine.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from healthmes.mcp_server.caffeine_contract import (
+    BoundedCaffeineRecommendation,
+    CaffeineMg,
+    CaffeineProductForm,
+    CaffeineProposal,
+    CaffeineProposalFacts,
+    CaffeineProposalReason,
+    CaffeineProposalRequest,
+    CaffeineProposalStatus,
+    CaffeineRecommendationBasis,
+    EvidenceFreshness,
+    ProposalConfidence,
+    SupportedPopulationStatus,
+)
+from healthmes.mcp_server.caffeine_validation import (
+    current_event_baseline,
+    invalid_reason,
+    within_sleep_cutoff,
+)
+
+
+def propose_caffeine(request: CaffeineProposalRequest | None) -> CaffeineProposal:
+    if type(request) is not CaffeineProposalRequest:
+        return _result(
+            None,
+            CaffeineProposalStatus.INVALID_INPUT,
+            CaffeineProposalReason.INVALID_INPUT,
+        )
+    if reason := invalid_reason(request):
+        return _result(request, CaffeineProposalStatus.INVALID_INPUT, reason)
+    if request.event_id is None:
+        return _insufficient(request, CaffeineProposalReason.MISSING_TARGET_EVENT)
+    if request.sleep is None:
+        return _insufficient(request, CaffeineProposalReason.MISSING_SLEEP)
+    if not (
+        request.sleep.local_date is not None
+        and request.sleep.duration_minutes is not None
+        and bool(request.sleep.provider and request.sleep.provider.strip())
+        and bool(request.sleep.source_key and request.sleep.source_key.strip())
+    ):
+        return _insufficient(request, CaffeineProposalReason.INCOMPLETE_SLEEP_PROVENANCE)
+    if request.sleep.freshness is not EvidenceFreshness.CURRENT:
+        return _insufficient(request, CaffeineProposalReason.STALE_SLEEP)
+    if request.consumed_today_mg is None:
+        return _insufficient(request, CaffeineProposalReason.MISSING_TOTAL_INTAKE)
+    if not request.total_intake_complete:
+        return _insufficient(request, CaffeineProposalReason.INCOMPLETE_TOTAL_INTAKE)
+    if request.timing is None:
+        return _insufficient(request, CaffeineProposalReason.MISSING_TIMING)
+    if request.sleep.local_date != request.timing.intended_consumption_at.date():
+        return _insufficient(request, CaffeineProposalReason.STALE_SLEEP)
+
+    population = request.safety_context.population_status
+    if population is SupportedPopulationStatus.MINOR:
+        return _blocked(request, CaffeineProposalReason.UNSUPPORTED_POPULATION)
+    if population is not SupportedPopulationStatus.CONFIRMED_ADULT:
+        return _insufficient(request, CaffeineProposalReason.UNKNOWN_POPULATION)
+    if request.safety_context.contraindications:
+        return _blocked(request, CaffeineProposalReason.CLINICIAN_GUIDANCE_REQUIRED)
+    if request.product_form is not CaffeineProductForm.BEVERAGE_OR_FOOD:
+        return _blocked(request, CaffeineProposalReason.UNSUPPORTED_PRODUCT_FORM)
+    cutoff = within_sleep_cutoff(request)
+    if cutoff is None:
+        return _result(
+            request,
+            CaffeineProposalStatus.INVALID_INPUT,
+            CaffeineProposalReason.INVALID_INPUT,
+        )
+    if cutoff:
+        return _blocked(request, CaffeineProposalReason.WITHIN_SLEEP_CUTOFF)
+
+    ceiling = CaffeineMg(
+        min(
+            request.population_daily_guardrail.amount_mg,
+            request.personal_daily_limit.amount_mg,
+        )
+    )
+    raw_remaining = ceiling - request.consumed_today_mg
+    remaining = CaffeineMg(max(0, raw_remaining))
+    if raw_remaining <= 0:
+        reason = (
+            CaffeineProposalReason.DAILY_LIMIT_REACHED
+            if raw_remaining == 0
+            else CaffeineProposalReason.DAILY_LIMIT_EXCEEDED
+        )
+        return _result(
+            request,
+            CaffeineProposalStatus.NOOP,
+            reason,
+            ProposalConfidence.HIGH,
+            ceiling,
+            remaining,
+            CaffeineMg(0),
+            CaffeineMg(0),
+            CaffeineRecommendationBasis.NO_ADDITIONAL_CAFFEINE,
+        )
+
+    maximum = CaffeineMg(min(request.single_dose_guardrail.amount_mg, remaining))
+    baseline = request.personal_event_baseline
+    if not current_event_baseline(baseline, request):
+        return _result(
+            request,
+            CaffeineProposalStatus.PROPOSAL,
+            CaffeineProposalReason.PERSONAL_EVENT_BASELINE_UNAVAILABLE,
+            ProposalConfidence.MEDIUM,
+            ceiling,
+            remaining,
+            maximum,
+            basis=CaffeineRecommendationBasis.UPPER_BOUND_ONLY,
+        )
+    return _result(
+        request,
+        CaffeineProposalStatus.PROPOSAL,
+        CaffeineProposalReason.PERSONAL_EVENT_BASELINE_APPLIED,
+        ProposalConfidence.MEDIUM,
+        ceiling,
+        remaining,
+        maximum,
+        CaffeineMg(min(baseline.amount_mg, maximum)),
+        CaffeineRecommendationBasis.PERSONAL_EVENT_BASELINE,
+    )
+
+
+def _insufficient(
+    request: CaffeineProposalRequest,
+    reason: CaffeineProposalReason,
+) -> CaffeineProposal:
+    return _result(request, CaffeineProposalStatus.INSUFFICIENT_DATA, reason)
+
+
+def _blocked(
+    request: CaffeineProposalRequest,
+    reason: CaffeineProposalReason,
+) -> CaffeineProposal:
+    return _result(request, CaffeineProposalStatus.NOOP, reason)
+
+
+def _result(
+    request: CaffeineProposalRequest | None,
+    status: CaffeineProposalStatus,
+    reason: CaffeineProposalReason,
+    confidence: ProposalConfidence = ProposalConfidence.LOW,
+    ceiling: CaffeineMg | None = None,
+    remaining: CaffeineMg | None = None,
+    maximum: CaffeineMg | None = None,
+    suggested: CaffeineMg | None = None,
+    basis: CaffeineRecommendationBasis = CaffeineRecommendationBasis.UNAVAILABLE,
+) -> CaffeineProposal:
+    facts = CaffeineProposalFacts(request, ceiling, remaining)
+    recommendation = BoundedCaffeineRecommendation(maximum, suggested, basis)
+    return CaffeineProposal(status, facts, recommendation, confidence, reason)

--- a/healthmes/mcp_server/caffeine_contract.py
+++ b/healthmes/mcp_server/caffeine_contract.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from enum import StrEnum
+from typing import NewType
+
+CalendarEventId = NewType("CalendarEventId", str)
+CaffeineMg = NewType("CaffeineMg", int)
+
+
+class EvidenceFreshness(StrEnum):
+    CURRENT = "current"
+    STALE = "stale"
+
+
+SleepFreshness = EvidenceFreshness
+BaselineFreshness = EvidenceFreshness
+
+
+class CaffeineProposalStatus(StrEnum):
+    PROPOSAL = "proposal"
+    NOOP = "noop"
+    INSUFFICIENT_DATA = "insufficient_data"
+    INVALID_INPUT = "invalid_input"
+
+
+class ProposalConfidence(StrEnum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class CaffeineProposalReason(StrEnum):
+    PERSONAL_EVENT_BASELINE_APPLIED = "personal_event_baseline_applied"
+    PERSONAL_EVENT_BASELINE_UNAVAILABLE = "personal_event_baseline_unavailable"
+    DAILY_LIMIT_REACHED = "daily_limit_reached"
+    DAILY_LIMIT_EXCEEDED = "daily_limit_exceeded"
+    MISSING_TARGET_EVENT = "missing_target_event"
+    MISSING_SLEEP = "missing_sleep"
+    STALE_SLEEP = "stale_sleep"
+    MISSING_TOTAL_INTAKE = "missing_total_intake"
+    INCOMPLETE_TOTAL_INTAKE = "incomplete_total_intake"
+    MISSING_TIMING = "missing_timing"
+    UNKNOWN_POPULATION = "unknown_population"
+    WITHIN_SLEEP_CUTOFF = "within_sleep_cutoff"
+    UNSUPPORTED_POPULATION = "unsupported_population"
+    CLINICIAN_GUIDANCE_REQUIRED = "clinician_guidance_required"
+    UNSUPPORTED_PRODUCT_FORM = "unsupported_product_form"
+    INCOMPLETE_SLEEP_PROVENANCE = "incomplete_sleep_provenance"
+    INVALID_CONSUMED_CAFFEINE = "invalid_consumed_caffeine"
+    INVALID_PERSONAL_LIMIT = "invalid_personal_limit"
+    INVALID_INPUT = "invalid_input"
+
+
+class CaffeineRecommendationBasis(StrEnum):
+    PERSONAL_EVENT_BASELINE = "personal_event_baseline"
+    UPPER_BOUND_ONLY = "upper_bound_only"
+    NO_ADDITIONAL_CAFFEINE = "no_additional_caffeine"
+    UNAVAILABLE = "unavailable"
+
+
+class SupportedPopulationStatus(StrEnum):
+    CONFIRMED_ADULT = "confirmed_adult"
+    MINOR = "minor"
+    UNKNOWN = "unknown"
+
+
+class CaffeineContraindication(StrEnum):
+    PREGNANCY_OR_BREASTFEEDING = "pregnancy_or_breastfeeding"
+    TRYING_TO_BECOME_PREGNANT = "trying_to_become_pregnant"
+    RELEVANT_MEDICATION_OR_CONDITION = "relevant_medication_or_condition"
+    PRONOUNCED_SENSITIVITY = "pronounced_sensitivity"
+    ADVERSE_SYMPTOMS = "adverse_symptoms"
+
+
+class CaffeineProductForm(StrEnum):
+    BEVERAGE_OR_FOOD = "beverage_or_food"
+    PURE_POWDER = "pure_powder"
+    HIGHLY_CONCENTRATED_LIQUID = "highly_concentrated_liquid"
+
+
+@dataclass(frozen=True, slots=True)
+class SleepEvidence:
+    local_date: date | None
+    duration_minutes: int | None
+    provider: str | None
+    source_key: str | None
+    freshness: EvidenceFreshness
+
+
+@dataclass(frozen=True, slots=True)
+class SourcedCaffeineLimit:
+    amount_mg: CaffeineMg
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class PopulationDailyCaffeineGuardrail(SourcedCaffeineLimit):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class PersonalDailyCaffeineLimit(SourcedCaffeineLimit):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class SingleDoseCaffeineGuardrail(SourcedCaffeineLimit):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class PersonalEventCaffeineBaseline:
+    event_id: CalendarEventId
+    amount_mg: CaffeineMg
+    source: str
+    source_key: str
+    confirmed_at: datetime
+    freshness: EvidenceFreshness
+
+
+@dataclass(frozen=True, slots=True)
+class CaffeineTiming:
+    intended_consumption_at: datetime
+    target_sleep_at: datetime
+    cutoff_before_sleep: timedelta
+
+
+@dataclass(frozen=True, slots=True)
+class CaffeineSafetyContext:
+    population_status: SupportedPopulationStatus
+    contraindications: frozenset[CaffeineContraindication] = frozenset()
+
+
+@dataclass(frozen=True, slots=True)
+class CaffeineProposalRequest:
+    event_id: CalendarEventId | None
+    sleep: SleepEvidence | None
+    consumed_today_mg: CaffeineMg | None
+    total_intake_complete: bool
+    population_daily_guardrail: PopulationDailyCaffeineGuardrail
+    personal_daily_limit: PersonalDailyCaffeineLimit
+    single_dose_guardrail: SingleDoseCaffeineGuardrail
+    personal_event_baseline: PersonalEventCaffeineBaseline | None
+    timing: CaffeineTiming | None
+    safety_context: CaffeineSafetyContext
+    product_form: CaffeineProductForm
+
+
+@dataclass(frozen=True, slots=True)
+class CaffeineProposalFacts:
+    request: CaffeineProposalRequest | None
+    effective_daily_ceiling_mg: CaffeineMg | None
+    remaining_daily_allowance_mg: CaffeineMg | None
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedCaffeineRecommendation:
+    maximum_additional_mg: CaffeineMg | None
+    suggested_additional_mg: CaffeineMg | None
+    basis: CaffeineRecommendationBasis
+
+
+@dataclass(frozen=True, slots=True)
+class CaffeineProposal:
+    status: CaffeineProposalStatus
+    facts: CaffeineProposalFacts
+    recommendation: BoundedCaffeineRecommendation
+    confidence: ProposalConfidence
+    reason: CaffeineProposalReason

--- a/healthmes/mcp_server/caffeine_contract.py
+++ b/healthmes/mcp_server/caffeine_contract.py
@@ -82,6 +82,8 @@ class CaffeineProductForm(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class SleepEvidence:
+    """Wearable sleep evidence dated in the user's local-day convention."""
+
     local_date: date | None
     duration_minutes: int | None
     provider: str | None
@@ -112,6 +114,8 @@ class SingleDoseCaffeineGuardrail(SourcedCaffeineLimit):
 
 @dataclass(frozen=True, slots=True)
 class PersonalEventCaffeineBaseline:
+    """Event-bound baseline with an opaque, non-empty provenance key."""
+
     event_id: CalendarEventId
     amount_mg: CaffeineMg
     source: str

--- a/healthmes/mcp_server/caffeine_validation.py
+++ b/healthmes/mcp_server/caffeine_validation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from healthmes.mcp_server.caffeine_contract import (
     CaffeineContraindication,
@@ -64,7 +64,7 @@ def current_event_baseline(
             and bool(baseline.source_key.strip())
             and _aware(baseline.confirmed_at)
             and timing is not None
-            and baseline.confirmed_at <= timing.intended_consumption_at
+            and _utc(baseline.confirmed_at) <= _utc(timing.intended_consumption_at)
         )
     except Exception:
         return False
@@ -75,7 +75,10 @@ def within_sleep_cutoff(request: CaffeineProposalRequest) -> bool | None:
     if timing is None:
         return None
     try:
-        return timing.target_sleep_at - timing.intended_consumption_at < timing.cutoff_before_sleep
+        return (
+            _utc(timing.target_sleep_at) - _utc(timing.intended_consumption_at)
+            < timing.cutoff_before_sleep
+        )
     except Exception:
         return None
 
@@ -143,7 +146,7 @@ def _invalid_timing(timing: CaffeineTiming) -> bool:
         return (
             not _aware(timing.intended_consumption_at)
             or not _aware(timing.target_sleep_at)
-            or timing.target_sleep_at <= timing.intended_consumption_at
+            or _utc(timing.target_sleep_at) <= _utc(timing.intended_consumption_at)
             or timing.cutoff_before_sleep <= timedelta(0)
         )
     except Exception:
@@ -155,3 +158,7 @@ def _aware(value: datetime) -> bool:
         return value.tzinfo is not None and value.utcoffset() is not None
     except Exception:
         return False
+
+
+def _utc(value: datetime) -> datetime:
+    return value.astimezone(UTC)

--- a/healthmes/mcp_server/caffeine_validation.py
+++ b/healthmes/mcp_server/caffeine_validation.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from healthmes.mcp_server.caffeine_contract import (
+    CaffeineContraindication,
+    CaffeineProposalReason,
+    CaffeineProposalRequest,
+    CaffeineSafetyContext,
+    CaffeineTiming,
+    EvidenceFreshness,
+    PersonalDailyCaffeineLimit,
+    PersonalEventCaffeineBaseline,
+    PopulationDailyCaffeineGuardrail,
+    SingleDoseCaffeineGuardrail,
+    SleepEvidence,
+)
+
+
+def invalid_reason(request: CaffeineProposalRequest) -> CaffeineProposalReason | None:
+    if _malformed(request):
+        return CaffeineProposalReason.INVALID_INPUT
+    if request.event_id is not None and not request.event_id.strip():
+        return CaffeineProposalReason.INVALID_INPUT
+    if request.sleep is not None and request.sleep.duration_minutes is not None:
+        if request.sleep.duration_minutes <= 0:
+            return CaffeineProposalReason.INVALID_INPUT
+    if request.consumed_today_mg is not None and request.consumed_today_mg < 0:
+        return CaffeineProposalReason.INVALID_CONSUMED_CAFFEINE
+    if (
+        request.personal_daily_limit.amount_mg <= 0
+        or not request.personal_daily_limit.source.strip()
+    ):
+        return CaffeineProposalReason.INVALID_PERSONAL_LIMIT
+    if any(
+        limit.amount_mg <= 0 or not limit.source.strip()
+        for limit in (
+            request.population_daily_guardrail,
+            request.single_dose_guardrail,
+        )
+    ):
+        return CaffeineProposalReason.INVALID_INPUT
+    if (
+        request.personal_event_baseline is not None
+        and request.personal_event_baseline.amount_mg <= 0
+    ):
+        return CaffeineProposalReason.INVALID_INPUT
+    if request.timing is not None and _invalid_timing(request.timing):
+        return CaffeineProposalReason.INVALID_INPUT
+    return None
+
+
+def current_event_baseline(
+    baseline: PersonalEventCaffeineBaseline | None,
+    request: CaffeineProposalRequest,
+) -> bool:
+    timing = request.timing
+    try:
+        return (
+            baseline is not None
+            and baseline.freshness is EvidenceFreshness.CURRENT
+            and baseline.event_id == request.event_id
+            and bool(baseline.source.strip())
+            and bool(baseline.source_key.strip())
+            and _aware(baseline.confirmed_at)
+            and timing is not None
+            and baseline.confirmed_at <= timing.intended_consumption_at
+        )
+    except Exception:
+        return False
+
+
+def within_sleep_cutoff(request: CaffeineProposalRequest) -> bool | None:
+    timing = request.timing
+    if timing is None:
+        return None
+    try:
+        return timing.target_sleep_at - timing.intended_consumption_at < timing.cutoff_before_sleep
+    except Exception:
+        return None
+
+
+def _malformed(request: CaffeineProposalRequest) -> bool:
+    sleep = request.sleep
+    baseline = request.personal_event_baseline
+    timing = request.timing
+    safety = request.safety_context
+    limits = (
+        (request.population_daily_guardrail, PopulationDailyCaffeineGuardrail),
+        (request.personal_daily_limit, PersonalDailyCaffeineLimit),
+        (request.single_dose_guardrail, SingleDoseCaffeineGuardrail),
+    )
+    return (
+        (request.event_id is not None and type(request.event_id) is not str)
+        or (
+            sleep is not None
+            and (
+                type(sleep) is not SleepEvidence
+                or (sleep.local_date is not None and type(sleep.local_date) is not date)
+                or (sleep.duration_minutes is not None and type(sleep.duration_minutes) is not int)
+                or (sleep.provider is not None and type(sleep.provider) is not str)
+                or (sleep.source_key is not None and type(sleep.source_key) is not str)
+                or type(sleep.freshness) is not EvidenceFreshness
+            )
+        )
+        or (request.consumed_today_mg is not None and type(request.consumed_today_mg) is not int)
+        or type(request.total_intake_complete) is not bool
+        or any(
+            type(limit) is not expected
+            or type(limit.amount_mg) is not int
+            or type(limit.source) is not str
+            for limit, expected in limits
+        )
+        or (
+            baseline is not None
+            and (
+                type(baseline) is not PersonalEventCaffeineBaseline
+                or type(baseline.event_id) is not str
+                or type(baseline.amount_mg) is not int
+                or type(baseline.source) is not str
+                or type(baseline.source_key) is not str
+                or type(baseline.confirmed_at) is not datetime
+                or type(baseline.freshness) is not EvidenceFreshness
+            )
+        )
+        or (
+            timing is not None
+            and (
+                type(timing) is not CaffeineTiming
+                or type(timing.intended_consumption_at) is not datetime
+                or type(timing.target_sleep_at) is not datetime
+                or type(timing.cutoff_before_sleep) is not timedelta
+            )
+        )
+        or type(safety) is not CaffeineSafetyContext
+        or type(safety.contraindications) is not frozenset
+        or any(type(item) is not CaffeineContraindication for item in safety.contraindications)
+    )
+
+
+def _invalid_timing(timing: CaffeineTiming) -> bool:
+    try:
+        return (
+            not _aware(timing.intended_consumption_at)
+            or not _aware(timing.target_sleep_at)
+            or timing.target_sleep_at <= timing.intended_consumption_at
+            or timing.cutoff_before_sleep <= timedelta(0)
+        )
+    except Exception:
+        return True
+
+
+def _aware(value: datetime) -> bool:
+    try:
+        return value.tzinfo is not None and value.utcoffset() is not None
+    except Exception:
+        return False

--- a/tests/mcp_server/test_caffeine.py
+++ b/tests/mcp_server/test_caffeine.py
@@ -1,6 +1,7 @@
 from dataclasses import fields, replace
 from datetime import UTC, date, datetime, timedelta, timezone, tzinfo
 from typing import cast
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -490,6 +491,50 @@ def test_exceptional_baseline_timezone_removes_exact_suggestion() -> None:
     assert result.reason is CaffeineProposalReason.PERSONAL_EVENT_BASELINE_UNAVAILABLE
 
 
+def test_baseline_confirmed_after_consumption_during_dst_fallback_is_unavailable() -> None:
+    request = _valid_request()
+    local_timezone = ZoneInfo("America/New_York")
+    timing = replace(
+        request.timing,
+        intended_consumption_at=datetime(
+            2026,
+            11,
+            1,
+            1,
+            45,
+            tzinfo=local_timezone,
+            fold=0,
+        ),
+        target_sleep_at=datetime(2026, 11, 1, 23, tzinfo=local_timezone),
+    )
+    baseline = replace(
+        _event_baseline(),
+        confirmed_at=datetime(
+            2026,
+            11,
+            1,
+            1,
+            30,
+            tzinfo=local_timezone,
+            fold=1,
+        ),
+    )
+    sleep = replace(request.sleep, local_date=date(2026, 11, 1))
+
+    result = propose_caffeine(
+        replace(
+            request,
+            sleep=sleep,
+            timing=timing,
+            personal_event_baseline=baseline,
+        )
+    )
+
+    assert result.status is CaffeineProposalStatus.PROPOSAL
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.PERSONAL_EVENT_BASELINE_UNAVAILABLE
+
+
 def test_same_inputs_always_return_same_result() -> None:
     first = propose_caffeine(_valid_request())
     second = propose_caffeine(_valid_request())
@@ -574,6 +619,23 @@ def test_consumption_at_sleep_cutoff_is_allowed() -> None:
 
     assert result.status is CaffeineProposalStatus.PROPOSAL
     assert result.recommendation.suggested_additional_mg == 100
+
+
+def test_sleep_cutoff_uses_elapsed_time_across_dst_spring_forward() -> None:
+    request = _valid_request()
+    local_timezone = ZoneInfo("America/New_York")
+    timing = CaffeineTiming(
+        intended_consumption_at=datetime(2026, 3, 8, 0, 30, tzinfo=local_timezone),
+        target_sleep_at=datetime(2026, 3, 8, 6, 30, tzinfo=local_timezone),
+        cutoff_before_sleep=timedelta(hours=6),
+    )
+    sleep = replace(request.sleep, local_date=date(2026, 3, 8))
+
+    result = propose_caffeine(replace(request, sleep=sleep, timing=timing))
+
+    assert result.status is CaffeineProposalStatus.NOOP
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.WITHIN_SLEEP_CUTOFF
 
 
 def test_minor_returns_noop_without_numeric_proposal() -> None:

--- a/tests/mcp_server/test_caffeine.py
+++ b/tests/mcp_server/test_caffeine.py
@@ -1,5 +1,5 @@
 from dataclasses import fields, replace
-from datetime import date, datetime, timedelta, timezone, tzinfo
+from datetime import UTC, date, datetime, timedelta, timezone, tzinfo
 from typing import cast
 
 import pytest
@@ -208,6 +208,16 @@ def test_unbound_event_baseline_never_returns_exact_suggestion(
     assert result.reason is CaffeineProposalReason.PERSONAL_EVENT_BASELINE_UNAVAILABLE
 
 
+def test_nonempty_baseline_source_key_is_audit_provenance() -> None:
+    baseline = replace(_event_baseline(), source_key="audit-record:another-opaque-id")
+
+    result = propose_caffeine(replace(_valid_request(), personal_event_baseline=baseline))
+
+    assert result.status is CaffeineProposalStatus.PROPOSAL
+    assert result.recommendation.suggested_additional_mg == 100
+    assert result.reason is CaffeineProposalReason.PERSONAL_EVENT_BASELINE_APPLIED
+
+
 def test_negative_consumed_caffeine_is_invalid() -> None:
     request = replace(_valid_request(), consumed_today_mg=CaffeineMg(-10))
 
@@ -275,6 +285,22 @@ def test_sleep_date_must_match_proposal_date(sleep_date: date) -> None:
     sleep = replace(request.sleep, local_date=sleep_date)
 
     result = propose_caffeine(replace(request, sleep=sleep))
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.STALE_SLEEP
+
+
+def test_timing_from_another_local_day_convention_fails_closed() -> None:
+    request = _valid_request()
+    timing = CaffeineTiming(
+        intended_consumption_at=datetime(2026, 7, 30, 16, tzinfo=UTC),
+        target_sleep_at=datetime(2026, 7, 31, 14, tzinfo=UTC),
+        cutoff_before_sleep=timedelta(hours=6),
+    )
+
+    result = propose_caffeine(replace(request, timing=timing))
 
     assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
     assert result.recommendation.maximum_additional_mg is None

--- a/tests/mcp_server/test_caffeine.py
+++ b/tests/mcp_server/test_caffeine.py
@@ -1,0 +1,617 @@
+from dataclasses import fields, replace
+from datetime import date, datetime, timedelta, timezone, tzinfo
+from typing import cast
+
+import pytest
+
+from healthmes.mcp_server.caffeine import propose_caffeine
+from healthmes.mcp_server.caffeine_contract import (
+    BaselineFreshness,
+    BoundedCaffeineRecommendation,
+    CaffeineContraindication,
+    CaffeineMg,
+    CaffeineProductForm,
+    CaffeineProposal,
+    CaffeineProposalFacts,
+    CaffeineProposalReason,
+    CaffeineProposalRequest,
+    CaffeineProposalStatus,
+    CaffeineRecommendationBasis,
+    CaffeineSafetyContext,
+    CaffeineTiming,
+    CalendarEventId,
+    PersonalDailyCaffeineLimit,
+    PersonalEventCaffeineBaseline,
+    PopulationDailyCaffeineGuardrail,
+    ProposalConfidence,
+    SingleDoseCaffeineGuardrail,
+    SleepEvidence,
+    SleepFreshness,
+    SupportedPopulationStatus,
+)
+
+KST = timezone(timedelta(hours=9))
+EVENT_ID = CalendarEventId("coffee-chat-2026-07-31")
+
+
+class ExplodingTimezone(tzinfo):
+    def utcoffset(self, dt: datetime | None) -> timedelta | None:
+        raise RuntimeError("invalid external timezone")
+
+    def dst(self, dt: datetime | None) -> timedelta | None:
+        return None
+
+
+def _event_baseline(amount_mg: int = 100) -> PersonalEventCaffeineBaseline:
+    return PersonalEventCaffeineBaseline(
+        event_id=EVENT_ID,
+        amount_mg=CaffeineMg(amount_mg),
+        source="user_confirmed",
+        source_key="event-baseline:coffee-chat-2026-07-31",
+        confirmed_at=datetime(2026, 7, 31, 12, tzinfo=KST),
+        freshness=BaselineFreshness.CURRENT,
+    )
+
+
+def _valid_request() -> CaffeineProposalRequest:
+    return CaffeineProposalRequest(
+        event_id=EVENT_ID,
+        sleep=SleepEvidence(
+            local_date=date(2026, 7, 31),
+            duration_minutes=374,
+            provider="oura",
+            source_key="oura:2026-07-31",
+            freshness=SleepFreshness.CURRENT,
+        ),
+        consumed_today_mg=CaffeineMg(100),
+        total_intake_complete=True,
+        population_daily_guardrail=PopulationDailyCaffeineGuardrail(
+            amount_mg=CaffeineMg(400),
+            source="fda_population_guidance",
+        ),
+        personal_daily_limit=PersonalDailyCaffeineLimit(
+            amount_mg=CaffeineMg(300),
+            source="user_profile",
+        ),
+        single_dose_guardrail=SingleDoseCaffeineGuardrail(
+            amount_mg=CaffeineMg(200),
+            source="efsa_population_guidance",
+        ),
+        personal_event_baseline=_event_baseline(),
+        timing=CaffeineTiming(
+            intended_consumption_at=datetime(2026, 7, 31, 13, tzinfo=KST),
+            target_sleep_at=datetime(2026, 7, 31, 23, tzinfo=KST),
+            cutoff_before_sleep=timedelta(hours=6),
+        ),
+        safety_context=CaffeineSafetyContext(
+            population_status=SupportedPopulationStatus.CONFIRMED_ADULT,
+        ),
+        product_form=CaffeineProductForm.BEVERAGE_OR_FOOD,
+    )
+
+
+def test_valid_inputs_return_personalized_bounded_proposal() -> None:
+    request = _valid_request()
+
+    result = propose_caffeine(request)
+
+    assert result == CaffeineProposal(
+        status=CaffeineProposalStatus.PROPOSAL,
+        facts=CaffeineProposalFacts(
+            request=request,
+            effective_daily_ceiling_mg=CaffeineMg(300),
+            remaining_daily_allowance_mg=CaffeineMg(200),
+        ),
+        recommendation=BoundedCaffeineRecommendation(
+            maximum_additional_mg=CaffeineMg(200),
+            suggested_additional_mg=CaffeineMg(100),
+            basis=CaffeineRecommendationBasis.PERSONAL_EVENT_BASELINE,
+        ),
+        confidence=ProposalConfidence.MEDIUM,
+        reason=CaffeineProposalReason.PERSONAL_EVENT_BASELINE_APPLIED,
+    )
+
+
+def test_consumed_at_daily_limit_returns_zero_mg_noop() -> None:
+    request = replace(_valid_request(), consumed_today_mg=CaffeineMg(300))
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.NOOP
+    assert result.facts.remaining_daily_allowance_mg == 0
+    assert result.recommendation == BoundedCaffeineRecommendation(
+        maximum_additional_mg=CaffeineMg(0),
+        suggested_additional_mg=CaffeineMg(0),
+        basis=CaffeineRecommendationBasis.NO_ADDITIONAL_CAFFEINE,
+    )
+    assert result.reason is CaffeineProposalReason.DAILY_LIMIT_REACHED
+
+
+def test_consumed_above_daily_limit_clamps_to_zero_noop() -> None:
+    request = replace(_valid_request(), consumed_today_mg=CaffeineMg(350))
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.NOOP
+    assert result.facts.remaining_daily_allowance_mg == 0
+    assert result.recommendation.maximum_additional_mg == 0
+    assert result.recommendation.suggested_additional_mg == 0
+    assert result.reason is CaffeineProposalReason.DAILY_LIMIT_EXCEEDED
+
+
+def test_single_dose_guardrail_caps_additional_amount() -> None:
+    request = replace(
+        _valid_request(),
+        consumed_today_mg=CaffeineMg(0),
+        personal_daily_limit=PersonalDailyCaffeineLimit(
+            amount_mg=CaffeineMg(400),
+            source="user_profile",
+        ),
+        single_dose_guardrail=SingleDoseCaffeineGuardrail(
+            amount_mg=CaffeineMg(150),
+            source="configured_population_guidance",
+        ),
+        personal_event_baseline=_event_baseline(180),
+    )
+
+    result = propose_caffeine(request)
+
+    assert result.facts.remaining_daily_allowance_mg == 400
+    assert result.recommendation.maximum_additional_mg == 150
+    assert result.recommendation.suggested_additional_mg == 150
+
+
+@pytest.mark.parametrize(
+    "baseline",
+    [
+        None,
+        replace(_event_baseline(), freshness=BaselineFreshness.STALE),
+    ],
+)
+def test_unavailable_event_baseline_returns_upper_bound_only(
+    baseline: PersonalEventCaffeineBaseline | None,
+) -> None:
+    request = replace(_valid_request(), personal_event_baseline=baseline)
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.PROPOSAL
+    assert result.recommendation == BoundedCaffeineRecommendation(
+        maximum_additional_mg=CaffeineMg(200),
+        suggested_additional_mg=None,
+        basis=CaffeineRecommendationBasis.UPPER_BOUND_ONLY,
+    )
+    assert result.reason is CaffeineProposalReason.PERSONAL_EVENT_BASELINE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    "baseline",
+    [
+        replace(_event_baseline(), event_id=CalendarEventId("another-event")),
+        replace(_event_baseline(), source=""),
+        replace(_event_baseline(), source_key=""),
+        replace(_event_baseline(), confirmed_at=datetime(2026, 7, 31, 12)),
+        replace(
+            _event_baseline(),
+            confirmed_at=datetime(2026, 7, 31, 14, tzinfo=KST),
+        ),
+    ],
+)
+def test_unbound_event_baseline_never_returns_exact_suggestion(
+    baseline: PersonalEventCaffeineBaseline,
+) -> None:
+    result = propose_caffeine(replace(_valid_request(), personal_event_baseline=baseline))
+
+    assert result.status is CaffeineProposalStatus.PROPOSAL
+    assert result.recommendation.maximum_additional_mg == 200
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.PERSONAL_EVENT_BASELINE_UNAVAILABLE
+
+
+def test_negative_consumed_caffeine_is_invalid() -> None:
+    request = replace(_valid_request(), consumed_today_mg=CaffeineMg(-10))
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.INVALID_INPUT
+    assert result.facts.effective_daily_ceiling_mg is None
+    assert result.facts.remaining_daily_allowance_mg is None
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.INVALID_CONSUMED_CAFFEINE
+
+
+@pytest.mark.parametrize("limit_mg", [0, -10])
+def test_non_positive_personal_limit_is_invalid(limit_mg: int) -> None:
+    request = replace(
+        _valid_request(),
+        personal_daily_limit=PersonalDailyCaffeineLimit(
+            amount_mg=CaffeineMg(limit_mg),
+            source="user_profile",
+        ),
+    )
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.INVALID_INPUT
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.INVALID_PERSONAL_LIMIT
+
+
+def test_missing_calendar_event_returns_insufficient_data() -> None:
+    result = propose_caffeine(replace(_valid_request(), event_id=None))
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.MISSING_TARGET_EVENT
+
+
+def test_missing_sleep_returns_insufficient_data() -> None:
+    result = propose_caffeine(replace(_valid_request(), sleep=None))
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.MISSING_SLEEP
+
+
+def test_stale_sleep_returns_insufficient_data() -> None:
+    request = _valid_request()
+    stale_sleep = replace(request.sleep, freshness=SleepFreshness.STALE)
+
+    result = propose_caffeine(replace(request, sleep=stale_sleep))
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.STALE_SLEEP
+
+
+@pytest.mark.parametrize("sleep_date", [date(2026, 7, 30), date(2099, 1, 1)])
+def test_sleep_date_must_match_proposal_date(sleep_date: date) -> None:
+    request = _valid_request()
+    sleep = replace(request.sleep, local_date=sleep_date)
+
+    result = propose_caffeine(replace(request, sleep=sleep))
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.STALE_SLEEP
+
+
+@pytest.mark.parametrize(
+    "sleep",
+    [
+        replace(_valid_request().sleep, provider=None),
+        replace(_valid_request().sleep, source_key=None),
+        replace(_valid_request().sleep, local_date=None),
+        replace(_valid_request().sleep, duration_minutes=None),
+    ],
+)
+def test_incomplete_sleep_provenance_returns_insufficient_data(
+    sleep: SleepEvidence,
+) -> None:
+    result = propose_caffeine(replace(_valid_request(), sleep=sleep))
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.INCOMPLETE_SLEEP_PROVENANCE
+
+
+@pytest.mark.parametrize(
+    ("proposal_request", "reason"),
+    [
+        (
+            replace(_valid_request(), consumed_today_mg=None),
+            CaffeineProposalReason.MISSING_TOTAL_INTAKE,
+        ),
+        (
+            replace(_valid_request(), total_intake_complete=False),
+            CaffeineProposalReason.INCOMPLETE_TOTAL_INTAKE,
+        ),
+        (replace(_valid_request(), timing=None), CaffeineProposalReason.MISSING_TIMING),
+        (
+            replace(
+                _valid_request(),
+                safety_context=CaffeineSafetyContext(
+                    population_status=SupportedPopulationStatus.UNKNOWN,
+                ),
+            ),
+            CaffeineProposalReason.UNKNOWN_POPULATION,
+        ),
+    ],
+)
+def test_other_missing_required_data_returns_insufficient_data(
+    proposal_request: CaffeineProposalRequest,
+    reason: CaffeineProposalReason,
+) -> None:
+    result = propose_caffeine(proposal_request)
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is reason
+
+
+@pytest.mark.parametrize(
+    "proposal_request",
+    [
+        replace(_valid_request(), event_id=CalendarEventId("")),
+        replace(
+            _valid_request(),
+            sleep=replace(_valid_request().sleep, duration_minutes=0),
+        ),
+        replace(
+            _valid_request(),
+            population_daily_guardrail=PopulationDailyCaffeineGuardrail(
+                amount_mg=CaffeineMg(0),
+                source="invalid",
+            ),
+        ),
+        replace(
+            _valid_request(),
+            single_dose_guardrail=SingleDoseCaffeineGuardrail(
+                amount_mg=CaffeineMg(0),
+                source="invalid",
+            ),
+        ),
+        replace(
+            _valid_request(),
+            personal_event_baseline=replace(_event_baseline(), amount_mg=CaffeineMg(0)),
+        ),
+        replace(
+            _valid_request(),
+            timing=CaffeineTiming(
+                intended_consumption_at=datetime(2026, 7, 31, 13),
+                target_sleep_at=datetime(2026, 7, 31, 23),
+                cutoff_before_sleep=timedelta(hours=6),
+            ),
+        ),
+    ],
+)
+def test_invalid_or_contradictory_inputs_return_invalid(
+    proposal_request: CaffeineProposalRequest,
+) -> None:
+    result = propose_caffeine(proposal_request)
+
+    assert result.status is CaffeineProposalStatus.INVALID_INPUT
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.INVALID_INPUT
+
+
+@pytest.mark.parametrize(
+    "proposal_request",
+    [
+        replace(_valid_request(), consumed_today_mg=cast(CaffeineMg, float("nan"))),
+        replace(_valid_request(), consumed_today_mg=cast(CaffeineMg, 12.5)),
+        replace(
+            _valid_request(),
+            population_daily_guardrail=PopulationDailyCaffeineGuardrail(
+                amount_mg=cast(CaffeineMg, "400"),
+                source="invalid_runtime_value",
+            ),
+        ),
+        replace(
+            _valid_request(),
+            sleep=replace(_valid_request().sleep, provider=cast(str, 7)),
+        ),
+        replace(
+            _valid_request(),
+            personal_event_baseline=replace(
+                _event_baseline(),
+                source=cast(str, 7),
+            ),
+        ),
+        replace(
+            _valid_request(),
+            total_intake_complete=cast(bool, "false"),
+        ),
+    ],
+)
+def test_malformed_runtime_values_fail_closed(
+    proposal_request: CaffeineProposalRequest,
+) -> None:
+    result = propose_caffeine(proposal_request)
+
+    assert result.status is CaffeineProposalStatus.INVALID_INPUT
+    assert result.facts.effective_daily_ceiling_mg is None
+    assert result.facts.remaining_daily_allowance_mg is None
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.INVALID_INPUT
+
+
+def test_missing_request_object_fails_closed() -> None:
+    result = propose_caffeine(None)
+
+    assert result.status is CaffeineProposalStatus.INVALID_INPUT
+    assert result.facts.request is None
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+
+
+def test_exceptional_timing_timezone_fails_closed() -> None:
+    request = _valid_request()
+    timing = replace(
+        request.timing,
+        intended_consumption_at=datetime(2026, 7, 31, 13, tzinfo=ExplodingTimezone()),
+    )
+
+    result = propose_caffeine(replace(request, timing=timing))
+
+    assert result.status is CaffeineProposalStatus.INVALID_INPUT
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+
+
+def test_exceptional_baseline_timezone_removes_exact_suggestion() -> None:
+    request = _valid_request()
+    baseline = replace(
+        _event_baseline(),
+        confirmed_at=datetime(2026, 7, 31, 12, tzinfo=ExplodingTimezone()),
+    )
+
+    result = propose_caffeine(replace(request, personal_event_baseline=baseline))
+
+    assert result.status is CaffeineProposalStatus.PROPOSAL
+    assert result.recommendation.maximum_additional_mg == 200
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.PERSONAL_EVENT_BASELINE_UNAVAILABLE
+
+
+def test_same_inputs_always_return_same_result() -> None:
+    first = propose_caffeine(_valid_request())
+    second = propose_caffeine(_valid_request())
+
+    assert first == second
+
+
+def test_output_preserves_safety_boundary() -> None:
+    request = _valid_request()
+
+    result = propose_caffeine(request)
+
+    assert result.facts.request.personal_daily_limit == request.personal_daily_limit
+    assert result.facts.request.personal_daily_limit.source == "user_profile"
+    assert {field.name for field in fields(CaffeineProposal)} == {
+        "status",
+        "facts",
+        "recommendation",
+        "confidence",
+        "reason",
+    }
+    assert {field.name for field in fields(BoundedCaffeineRecommendation)} == {
+        "maximum_additional_mg",
+        "suggested_additional_mg",
+        "basis",
+    }
+    output_text_values = (
+        result.status.value,
+        result.reason.value,
+        result.confidence.value,
+        result.recommendation.basis.value,
+        result.facts.request.personal_daily_limit.source,
+    )
+    forbidden_claims = ("safe", "안전", "medical", "의료")
+    assert all(
+        claim not in text.lower() for text in output_text_values for claim in forbidden_claims
+    )
+
+
+def test_short_sleep_never_increases_the_proposal() -> None:
+    short_sleep_request = _valid_request()
+    longer_sleep_request = replace(
+        short_sleep_request,
+        sleep=replace(short_sleep_request.sleep, duration_minutes=480),
+    )
+
+    short_sleep_result = propose_caffeine(short_sleep_request)
+    longer_sleep_result = propose_caffeine(longer_sleep_request)
+
+    assert short_sleep_result.recommendation == longer_sleep_result.recommendation
+
+
+def test_consumption_within_sleep_cutoff_returns_noop_without_numeric_proposal() -> None:
+    request = replace(
+        _valid_request(),
+        timing=CaffeineTiming(
+            intended_consumption_at=datetime(2026, 7, 31, 18, tzinfo=KST),
+            target_sleep_at=datetime(2026, 7, 31, 23, tzinfo=KST),
+            cutoff_before_sleep=timedelta(hours=6),
+        ),
+    )
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.NOOP
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.WITHIN_SLEEP_CUTOFF
+
+
+def test_consumption_at_sleep_cutoff_is_allowed() -> None:
+    request = replace(
+        _valid_request(),
+        timing=CaffeineTiming(
+            intended_consumption_at=datetime(2026, 7, 31, 17, tzinfo=KST),
+            target_sleep_at=datetime(2026, 7, 31, 23, tzinfo=KST),
+            cutoff_before_sleep=timedelta(hours=6),
+        ),
+    )
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.PROPOSAL
+    assert result.recommendation.suggested_additional_mg == 100
+
+
+def test_minor_returns_noop_without_numeric_proposal() -> None:
+    request = replace(
+        _valid_request(),
+        safety_context=CaffeineSafetyContext(
+            population_status=SupportedPopulationStatus.MINOR,
+        ),
+    )
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.NOOP
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.reason is CaffeineProposalReason.UNSUPPORTED_POPULATION
+
+
+@pytest.mark.parametrize("raw_status", ["minor", "confirmed_adult", "future_status"])
+def test_unvalidated_population_value_fails_closed(raw_status: str) -> None:
+    request = replace(
+        _valid_request(),
+        safety_context=CaffeineSafetyContext(
+            population_status=cast(SupportedPopulationStatus, raw_status),
+        ),
+    )
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.INSUFFICIENT_DATA
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.recommendation.suggested_additional_mg is None
+    assert result.reason is CaffeineProposalReason.UNKNOWN_POPULATION
+
+
+@pytest.mark.parametrize("contraindication", list(CaffeineContraindication))
+def test_declared_contraindication_returns_noop_without_numeric_proposal(
+    contraindication: CaffeineContraindication,
+) -> None:
+    request = replace(
+        _valid_request(),
+        safety_context=CaffeineSafetyContext(
+            population_status=SupportedPopulationStatus.CONFIRMED_ADULT,
+            contraindications=frozenset({contraindication}),
+        ),
+    )
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.NOOP
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.reason is CaffeineProposalReason.CLINICIAN_GUIDANCE_REQUIRED
+
+
+@pytest.mark.parametrize(
+    "product_form",
+    [CaffeineProductForm.PURE_POWDER, CaffeineProductForm.HIGHLY_CONCENTRATED_LIQUID],
+)
+def test_high_concentration_product_returns_noop_without_numeric_proposal(
+    product_form: CaffeineProductForm,
+) -> None:
+    request = replace(_valid_request(), product_form=product_form)
+
+    result = propose_caffeine(request)
+
+    assert result.status is CaffeineProposalStatus.NOOP
+    assert result.recommendation.maximum_additional_mg is None
+    assert result.reason is CaffeineProposalReason.UNSUPPORTED_PRODUCT_FORM


### PR DESCRIPTION
## Outcome

Adds the pure deterministic caffeine proposal contract requested by #82.

- separates population daily guardrails, user-provided daily ceilings, single-dose bounds, and event-bound personal baselines
- returns structured facts, recommendation, confidence, and reason
- fails closed for missing, stale, contradictory, malformed, or temporally mismatched evidence
- keeps provider access, Calendar mutation, approval, and delivery out of scope
- records the durable safety framing and evidence sources

## Safety boundary

The result is a bounded preparation proposal, not a safe dose or medical advice. Short sleep never increases the amount. Exact suggestions require current sleep dated to the proposal day and a sourced baseline bound to the exact event.

## Verification

- 60 focused caffeine contract tests
- 1,161 full repository tests
- Ruff and compileall
- 39-scenario manual QA plus 21 expanded malformed-input cases
- independent code/spec/security review: `APPROVE`
- independent architecture review: `CLEAR`
- exact reviewed head: `a2c58c2db18107a132b49fd9a570c2e04ff792e3`
- GitHub CI: 3/3 successful

Closes #82