### PR TITLE
chore(android): align AGP 9.3 and browser dependency

### DIFF
--- a/apps/android-usage/README.md
+++ b/apps/android-usage/README.md
@@ -17,16 +17,16 @@ deliberately *duplicates* its pairing-prefs pattern instead of importing it.
 
 ## Build matrix
 
-Toolchain for everything: Gradle 8.9 (wrapper), AGP 8.7.3, Kotlin 2.0.21
+Toolchain for everything: Gradle 9.6.1 (wrapper), AGP 9.3.1, Kotlin 2.0.21
 (+ `org.jetbrains.kotlin.plugin.compose` 2.0.21 for `:companion`'s Glance
-code), JDK 17+, `compileSdk = 35`. Point the build at an SDK with platform 35
+code), JDK 17+, `compileSdk = 36`. Point the build at an SDK with platform 36
 via `ANDROID_HOME` or `local.properties`.
 
 | Module | Type | minSdk | Key libraries | Build | JVM unit tests |
 |---|---|---|---|---|---|
 | `:app` | phone app | 26 | WorkManager 2.9.1, security-crypto | `:app:assembleDebug` | `:app:testDebugUnitTest` (hourly bucketing) |
 | `:shared` | library | 26 | security-crypto, org.json (platform) | `:shared:assembleDebug` | tested via `:companion` |
-| `:companion` | phone app | 26 | Compose BOM 2024.10.01 (material3), activity-compose 1.9.3, browser 1.8.0, Glance 1.1.1, WorkManager 2.9.1 | `:companion:assembleDebug` | `:companion:testDebugUnitTest` (glance/alerts/report/proposals contract parsers, state mapper, notification grammar + action plan, proposal-action logic, multipart upload bodies, curve geometry, focus-block selection) |
+| `:companion` | phone app | 26 | Compose BOM 2024.10.01 (material3), activity-compose 1.9.3, browser 1.10.0, Glance 1.1.1, WorkManager 2.9.1 | `:companion:assembleDebug` | `:companion:testDebugUnitTest` (glance/alerts/report/proposals contract parsers, state mapper, notification grammar + action plan, proposal-action logic, multipart upload bodies, curve geometry, focus-block selection) |
 | `:wear` | Wear OS app | 30 | tiles 1.4.1, protolayout 1.2.1, watchface-complications-data-source 1.2.1 | `:wear:assembleDebug` | — (logic lives in `:shared`, tested via `:companion`) |
 
 ```bash

--- a/apps/android-usage/app/build.gradle.kts
+++ b/apps/android-usage/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.healthmes.usagecollector"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.healthmes.usagecollector"

--- a/apps/android-usage/build.gradle.kts
+++ b/apps/android-usage/build.gradle.kts
@@ -1,9 +1,8 @@
-// Root build file: plugin versions only. Known-good matrix for Gradle 8.9
-// (gradle/wrapper/gradle-wrapper.properties): AGP 8.7.x requires Gradle >= 8.9
-// and JDK 17+, Kotlin 2.0.x is the matching stable Kotlin release.
+// Root build file: plugin versions only. AGP 9.3.x requires Gradle 9.5+
+// and JDK 17+; the wrapper is pinned to Gradle 9.6.1.
 plugins {
-    id("com.android.application") version "8.7.3" apply false
-    id("com.android.library") version "8.7.3" apply false
+    id("com.android.application") version "9.3.1" apply false
+    id("com.android.library") version "9.3.1" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     // Required by :companion for Glance (@Composable) widget code; with
     // Kotlin 2.x the Compose compiler ships as this Kotlin subplugin and its

--- a/apps/android-usage/companion/build.gradle.kts
+++ b/apps/android-usage/companion/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 // before.
 android {
     namespace = "com.healthmes.companion"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.healthmes.companion"
@@ -75,7 +75,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
 
     // Decision viewer: Custom Tabs first, in-app WebView fallback.
-    implementation("androidx.browser:browser:1.8.0")
+    implementation("androidx.browser:browser:1.10.0")
 
     testImplementation("junit:junit:4.13.2")
     // Unit tests exercise the shared org.json-based contract parsers on the

--- a/apps/android-usage/gradle.properties
+++ b/apps/android-usage/gradle.properties
@@ -10,5 +10,6 @@ android.nonTransitiveRClass=true
 # Keep the explicit Kotlin 2.0.21 plugins while the project migrates to
 # AGP 9's built-in Kotlin DSL in a dedicated change.
 android.builtInKotlin=false
+android.newDsl=false
 
 kotlin.code.style=official

--- a/apps/android-usage/gradle.properties
+++ b/apps/android-usage/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 # Namespaced R classes keep builds lean.
 android.nonTransitiveRClass=true
 
+# Keep the explicit Kotlin 2.0.21 plugins while the project migrates to
+# AGP 9's built-in Kotlin DSL in a dedicated change.
+android.builtInKotlin=false
+
 kotlin.code.style=official

--- a/apps/android-usage/shared/build.gradle.kts
+++ b/apps/android-usage/shared/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 // module stays untouched.
 android {
     namespace = "com.healthmes.briefing"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         // Must stay <= every consumer's minSdk (:companion 26, :wear 30).

--- a/apps/android-usage/wear/build.gradle.kts
+++ b/apps/android-usage/wear/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 // deliverable (docs/design/WATCH-NOTIFICATIONS.ko.md).
 android {
     namespace = "com.healthmes.wear"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.healthmes.wear"


### PR DESCRIPTION
## Summary

- update application and library Android Gradle Plugin versions together to 9.3.1
- retain the explicit Kotlin 2.0.21 toolchain through AGP 9's documented compatibility switch
- raise compileSdk to 36 and update androidx.browser to 1.10.0
- refresh the documented Android build matrix

## Why one PR

Dependabot PRs #76, #77, and #79 each fail when applied independently: Browser 1.10.0 requires a newer Android toolchain, while partial AGP 9 upgrades collide with the existing Kotlin Android plugin. This applies the three dependency changes as one coherent toolchain update.

## Verification

- git diff --check: passed
- local Android build: unavailable because this Mac has no Java runtime
- GitHub Android CI is the required build/test gate

Supersedes #76
Supersedes #77
Supersedes #79