### PR TITLE
fix: stabilize wearable recovery diagnostics

### DIFF
--- a/healthmes/__main__.py
+++ b/healthmes/__main__.py
@@ -58,6 +58,7 @@ from healthmes.calendars.sleep_job import (
     SleepReconciliationError,
     preview_recent_sleep,
 )
+from healthmes.calendars.sleep_recheck import recheck_sleep_night
 from healthmes.config import Settings, get_settings, is_loopback_host
 from healthmes.store import dispose_engine, init_engine
 
@@ -530,6 +531,13 @@ def _cmd_sleep_reconcile(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_sleep_recheck(args: argparse.Namespace) -> int:
+    settings = _cli_settings()
+    result = asyncio.run(recheck_sleep_night(settings, args.date))
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
 def _add_passphrase_file(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--passphrase-file",
@@ -712,6 +720,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Local sleep date (YYYY-MM-DD); default is today in the configured timezone.",
     )
     sleep_reconcile.set_defaults(func=_cmd_sleep_reconcile)
+    sleep_recheck = sleep_sub.add_parser(
+        "recheck",
+        help="Read only Open Wearables recheck for one named night; never writes Calendar.",
+    )
+    sleep_recheck.add_argument(
+        "--dry-run", action="store_true", required=True,
+        help="Required safety gate: requery only; never mutate Open Wearables or Calendar.",
+    )
+    sleep_recheck.add_argument("--date", type=dt.date.fromisoformat, required=True)
+    sleep_recheck.set_defaults(func=_cmd_sleep_recheck)
 
     return parser
 

--- a/healthmes/api/__init__.py
+++ b/healthmes/api/__init__.py
@@ -30,6 +30,7 @@ from healthmes.api import (
     insights,
     media,
     medical,
+    privacy,
     reports,
     schedule,
     sleep,
@@ -58,6 +59,7 @@ routers: list[APIRouter] = [
     connect.router,
     google_oauth.router,
     sleep.router,
+    privacy.router,
 ]
 
 

--- a/healthmes/api/auth.py
+++ b/healthmes/api/auth.py
@@ -56,7 +56,7 @@ __all__ = [
 # "/" is the static landing shell — it renders links only (no data, no
 # credentials in markup; healthmes/api/decisions.py::landing), so exposing it
 # leaks nothing while giving humans an entry point on the public host.
-OPEN_PATHS = frozenset({"/health", "/"})
+OPEN_PATHS = frozenset({"/health", "/", "/privacy"})
 
 # Path prefixes of the human-facing viewer surface that may authenticate via
 # the derived ?token= query credential (browser links cannot carry headers).

--- a/healthmes/api/connection_status.py
+++ b/healthmes/api/connection_status.py
@@ -7,6 +7,7 @@ from typing import Any, Protocol
 
 from healthmes.calendars import creds
 from healthmes.calendars.google_client import resolve_google_client_secret
+from healthmes.calendars.runtime_status import read_calendar_status
 from healthmes.config import Settings, resolve_timezone
 from healthmes.mcp_server.ow_client import (
     OWAuthError,
@@ -126,8 +127,22 @@ def build_connection_cards(settings: Settings) -> list[ConnectionCard]:
 def _google_card(settings: Settings) -> ConnectionCard:
     state = creds.google_connection_state(settings.data_dir)
     if state == "connected":
+        runtime = read_calendar_status(settings.data_dir).get("google", {})
+        if runtime.get("state") == "error":
+            return ConnectionCard(
+                "google", "Google Calendar mirror", False,
+                f"Google mirror 동기화 실패 ({runtime.get('error_type', 'unknown')})",
+                badge_label="오류",
+            )
         return ConnectionCard(
-            "google", "Google Calendar", True, "Google OAuth credential 확인됨"
+            "google",
+            "Google Calendar mirror",
+            True,
+            (
+                "Google mirror 정상"
+                if runtime.get("state") == "ok"
+                else "Google OAuth credential 확인됨"
+            ),
         )
     notes: list[str] = []
     if state == "invalid":
@@ -162,7 +177,17 @@ def _icloud_card(settings: Settings) -> ConnectionCard:
             if resolved.source == "env"
             else "CLI로 저장된 CalDAV credential 사용 중"
         )
-        return ConnectionCard("icloud", "iCloud 캘린더 (CalDAV)", True, detail)
+        runtime = read_calendar_status(settings.data_dir).get("caldav", {})
+        if runtime.get("state") == "error":
+            return ConnectionCard(
+                "icloud", "iCloud Calendar write", False,
+                f"iCloud write 동기화 실패 ({runtime.get('error_type', 'unknown')})",
+                badge_label="오류",
+            )
+        return ConnectionCard(
+            "icloud", "iCloud Calendar write", True,
+            "iCloud write 정상" if runtime.get("state") == "ok" else detail,
+        )
     return ConnectionCard(
         "icloud",
         "iCloud 캘린더 (CalDAV)",

--- a/healthmes/api/connection_status.py
+++ b/healthmes/api/connection_status.py
@@ -180,17 +180,16 @@ def _icloud_card(settings: Settings) -> ConnectionCard:
         runtime = read_calendar_status(settings.data_dir).get("caldav", {})
         if runtime.get("state") == "error":
             return ConnectionCard(
-                "icloud", "iCloud Calendar write", False,
-                f"iCloud write 동기화 실패 ({runtime.get('error_type', 'unknown')})",
+                "icloud", "Apple/iCloud Calendar write", False,
+                f"Apple/iCloud write 동기화 실패 ({runtime.get('error_type', 'unknown')})",
                 badge_label="오류",
             )
         return ConnectionCard(
-            "icloud", "iCloud Calendar write", True,
-            "iCloud write 정상" if runtime.get("state") == "ok" else detail,
+            "icloud", "Apple/iCloud Calendar write", True,
+            "Apple/iCloud write 정상" if runtime.get("state") == "ok" else detail,
         )
     return ConnectionCard(
-        "icloud",
-        "iCloud 캘린더 (CalDAV)",
+        "icloud", "Apple/iCloud Calendar write",
         False,
         "미연결 — 앱 암호 한 번 입력으로 연결됩니다 (숨김 프롬프트).",
         command=ICLOUD_CONNECT_COMMAND,

--- a/healthmes/api/privacy.py
+++ b/healthmes/api/privacy.py
@@ -2,13 +2,11 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
 from healthmes.api.decision_html import shell_context, template_environment
-from healthmes.config import Settings
 
 router = APIRouter(tags=["privacy"])
 
 
 @router.get("/privacy", response_class=HTMLResponse, include_in_schema=False)
 def privacy_page(request: Request) -> HTMLResponse:
-    settings: Settings = request.app.state.settings
     template = template_environment().get_template("ui/privacy.html.j2")
-    return HTMLResponse(template.render(active_nav="", **shell_context(settings)))
+    return HTMLResponse(template.render(active_nav="", **shell_context(None)))

--- a/healthmes/api/privacy.py
+++ b/healthmes/api/privacy.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from healthmes.api.decision_html import shell_context, template_environment
+from healthmes.config import Settings
+
+router = APIRouter(tags=["privacy"])
+
+
+@router.get("/privacy", response_class=HTMLResponse, include_in_schema=False)
+def privacy_page(request: Request) -> HTMLResponse:
+    settings: Settings = request.app.state.settings
+    template = template_environment().get_template("ui/privacy.html.j2")
+    return HTMLResponse(template.render(active_nav="", **shell_context(settings)))

--- a/healthmes/api/templates/ui/privacy.html.j2
+++ b/healthmes/api/templates/ui/privacy.html.j2
@@ -1,0 +1,23 @@
+{% extends "ui/_base.html.j2" %}
+
+{% block title %}HealthMes Privacy Policy{% endblock %}
+
+{% block content %}
+<section class="card" aria-labelledby="privacy-title">
+  <p class="eyebrow">HealthMes · Local developer build</p>
+  <h1 id="privacy-title">Privacy Policy</h1>
+  <p>Effective date: 2026-08-10</p>
+
+  <h2>What HealthMes reads</h2>
+  <p>When you authorize WHOOP, HealthMes reads only the scopes you approve: sleep, recovery, cycles, workouts, and profile. OAuth credentials and resulting health records are stored in your local HealthMes instance.</p>
+
+  <h2>How HealthMes uses data</h2>
+  <p>HealthMes uses the records to show health context and prepare local planning suggestions. Calendar changes are made only after an explicit local approval. HealthMes does not sell health data or use it for advertising.</p>
+
+  <h2>Storage, sharing, and control</h2>
+  <p>Data remains on the local instance unless you explicitly configure an optional encrypted backup or approve a calendar update. You can revoke WHOOP access in WHOOP, and you can delete locally stored records by removing the local HealthMes data.</p>
+
+  <h2>Contact</h2>
+  <p>For this developer build, open an issue in the HealthMes repository.</p>
+</section>
+{% endblock %}

--- a/healthmes/calendars/jobs.py
+++ b/healthmes/calendars/jobs.py
@@ -38,6 +38,7 @@ from healthmes.calendars.apple_google_mirror import mirror_apple_events_to_googl
 from healthmes.calendars.base import CalendarAuthError, CalendarBackend
 from healthmes.calendars.intake import intake_calendar_tasks
 from healthmes.calendars.proposal_push import push_accepted_proposals
+from healthmes.calendars.runtime_status import record_calendar_status
 from healthmes.calendars.state import (
     FilePendingDiffStore,
     FileSyncStateStore,
@@ -176,8 +177,19 @@ def build_calendar_job(
                     and write_source(settings) is CalendarSource.CALDAV
                 ):
                     mirror_apple_events_to_google(service, session)
+                record_calendar_status(
+                    settings.data_dir,
+                    source,
+                    mode=("write" if is_write_backend else "mirror"),
+                )
                 return diff
-        except Exception:
+        except Exception as exc:
+            record_calendar_status(
+                settings.data_dir,
+                source,
+                mode=("write" if is_write_backend else "mirror"),
+                error=exc,
+            )
             logger.exception(
                 "Calendar sync for %s failed; next interval will retry.", source.value
             )

--- a/healthmes/calendars/runtime_status.py
+++ b/healthmes/calendars/runtime_status.py
@@ -35,22 +35,25 @@ def record_calendar_status(
     error: Exception | None = None,
 ) -> None:
     path = _path(data_dir)
-    with _status_lock(path):
-        current = read_calendar_status(data_dir)
-        current[source.value] = {
-            "state": "error" if error is not None else "ok",
-            "mode": mode,
-            "updated_at": datetime.now(UTC).isoformat(),
-            "error_type": type(error).__name__ if error is not None else "",
-        }
-        fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as stream:
-                json.dump(current, stream, sort_keys=True)
-            os.replace(temporary, path)
-        finally:
-            if os.path.exists(temporary):
-                os.unlink(temporary)
+    try:
+        with _status_lock(path):
+            current = read_calendar_status(data_dir)
+            current[source.value] = {
+                "state": "error" if error is not None else "ok",
+                "mode": mode,
+                "updated_at": datetime.now(UTC).isoformat(),
+                "error_type": type(error).__name__ if error is not None else "",
+            }
+            fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                    json.dump(current, stream, sort_keys=True)
+                os.replace(temporary, path)
+            finally:
+                if os.path.exists(temporary):
+                    os.unlink(temporary)
+    except OSError:
+        return
 
 
 def read_calendar_status(data_dir: Path) -> dict[str, dict[str, str]]:

--- a/healthmes/calendars/runtime_status.py
+++ b/healthmes/calendars/runtime_status.py
@@ -59,7 +59,7 @@ def record_calendar_status(
 def read_calendar_status(data_dir: Path) -> dict[str, dict[str, str]]:
     try:
         raw: Any = json.loads(_path(data_dir).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return {}
     if not isinstance(raw, dict):
         return {}

--- a/healthmes/calendars/runtime_status.py
+++ b/healthmes/calendars/runtime_status.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import tempfile
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -14,6 +16,17 @@ def _path(data_dir: Path) -> Path:
     return data_dir / "runtime" / "calendar-status.json"
 
 
+@contextmanager
+def _status_lock(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
 def record_calendar_status(
     data_dir: Path,
     source: CalendarSource,
@@ -22,22 +35,22 @@ def record_calendar_status(
     error: Exception | None = None,
 ) -> None:
     path = _path(data_dir)
-    current = read_calendar_status(data_dir)
-    current[source.value] = {
-        "state": "error" if error is not None else "ok",
-        "mode": mode,
-        "updated_at": datetime.now(UTC).isoformat(),
-        "error_type": type(error).__name__ if error is not None else "",
-    }
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as stream:
-            json.dump(current, stream, sort_keys=True)
-        os.replace(temporary, path)
-    finally:
-        if os.path.exists(temporary):
-            os.unlink(temporary)
+    with _status_lock(path):
+        current = read_calendar_status(data_dir)
+        current[source.value] = {
+            "state": "error" if error is not None else "ok",
+            "mode": mode,
+            "updated_at": datetime.now(UTC).isoformat(),
+            "error_type": type(error).__name__ if error is not None else "",
+        }
+        fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                json.dump(current, stream, sort_keys=True)
+            os.replace(temporary, path)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
 
 
 def read_calendar_status(data_dir: Path) -> dict[str, dict[str, str]]:

--- a/healthmes/calendars/runtime_status.py
+++ b/healthmes/calendars/runtime_status.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from healthmes.store.enums import CalendarSource
+
+
+def _path(data_dir: Path) -> Path:
+    return data_dir / "runtime" / "calendar-status.json"
+
+
+def record_calendar_status(
+    data_dir: Path,
+    source: CalendarSource,
+    *,
+    mode: str,
+    error: Exception | None = None,
+) -> None:
+    path = _path(data_dir)
+    current = read_calendar_status(data_dir)
+    current[source.value] = {
+        "state": "error" if error is not None else "ok",
+        "mode": mode,
+        "updated_at": datetime.now(UTC).isoformat(),
+        "error_type": type(error).__name__ if error is not None else "",
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(current, stream, sort_keys=True)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def read_calendar_status(data_dir: Path) -> dict[str, dict[str, str]]:
+    try:
+        raw: Any = json.loads(_path(data_dir).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(source): {str(key): str(value) for key, value in entry.items()}
+        for source, entry in raw.items()
+        if isinstance(entry, dict)
+    }

--- a/healthmes/calendars/sleep_recheck.py
+++ b/healthmes/calendars/sleep_recheck.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date, timedelta
+from typing import Any, Protocol
+
+from healthmes.calendars.sleep_observation import ActualSleepObservation, SleepObservationNoOp
+from healthmes.calendars.sleep_source import read_actual_sleep
+from healthmes.config import Settings
+from healthmes.mcp_server.ow_client import (
+    OWAuthError,
+    OWClient,
+    OWClientError,
+    OWConfigurationError,
+    resolve_single_user_id,
+)
+
+
+class SleepRecheckReader(Protocol):
+    async def list_users(
+        self, *, search: str | None = None, limit: int = 100
+    ) -> Mapping[str, Any]: ...
+    async def get_connections(self, user_id: str) -> Sequence[object]: ...
+    async def collect_sleep_summaries(
+        self, user_id: str, start_date: str, end_date: str
+    ) -> Sequence[Mapping[str, Any]]: ...
+
+
+async def recheck_sleep_night(
+    settings: Settings,
+    night_start: date,
+    *,
+    client: SleepRecheckReader | None = None,
+) -> dict[str, object]:
+    reader = client or OWClient.from_settings(settings)
+    windows = {
+        "night_start": _window(night_start),
+        "oura_summary": _window(night_start + timedelta(days=1)),
+    }
+    try:
+        user_id = await resolve_single_user_id(reader, settings)
+        connections = await reader.get_connections(user_id)
+    except (OWAuthError, OWConfigurationError):
+        return _result("authentication_failure", windows)
+    except OWClientError:
+        return _result("api_transport_failure", windows)
+    except LookupError:
+        return _result("authentication_failure", windows)
+    if not _oura_is_active(connections):
+        return _result("vendor_sync_failure", windows)
+    try:
+        night = await read_actual_sleep(reader, user_id, night_start)
+        summary = await read_actual_sleep(reader, user_id, night_start + timedelta(days=1))
+    except (OWAuthError, OWConfigurationError):
+        return _result("authentication_failure", windows)
+    except OWClientError:
+        return _result("api_transport_failure", windows)
+    if isinstance(night, ActualSleepObservation):
+        return _result("ok", windows, selected_date=night.local_date.isoformat())
+    if isinstance(summary, ActualSleepObservation):
+        return _result("date_basis_mismatch", windows, selected_date=summary.local_date.isoformat())
+    if _incomplete(night, summary):
+        return _result("incomplete_record", windows)
+    return _result("no_provider_record", windows)
+
+
+def _window(day: date) -> dict[str, str]:
+    return {"start": day.isoformat(), "end": (day + timedelta(days=1)).isoformat()}
+
+
+def _oura_is_active(connections: Sequence[object]) -> bool:
+    return any(
+        isinstance(row, Mapping)
+        and str(row.get("provider", "")).strip().lower() == "oura"
+        and str(row.get("status", "")).strip().lower() == "active"
+        for row in connections
+    )
+
+
+def _incomplete(*observations: SleepObservationNoOp | ActualSleepObservation) -> bool:
+    return any(
+        isinstance(observation, SleepObservationNoOp)
+        and observation.reason.value in {"incomplete", "nap_only", "ambiguous"}
+        for observation in observations
+    )
+
+
+def _result(
+    outcome: str,
+    windows: dict[str, dict[str, str]],
+    *,
+    selected_date: str | None = None,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "status": "read_only_recheck",
+        "outcome": outcome,
+        "windows": windows,
+        "calendar_write": "unchanged",
+    }
+    if selected_date is not None:
+        result["selected_date"] = selected_date
+    return result

--- a/scripts/dev_mac.sh
+++ b/scripts/dev_mac.sh
@@ -19,7 +19,7 @@
 #   test             uv run pytest -q
 #   ow               best-effort native boot of vendor/open-wearables backend
 #                    (uv sync + scripts/start/app.sh; migrations + seeds +
-#                    `fastapi dev` when ENVIRONMENT=local)
+#                    a single `fastapi run` listener)
 #   ow-worker        celery worker of the open-wearables backend
 #                    (requires redis from services-start)
 #   ow-beat          celery beat scheduler of the open-wearables backend
@@ -302,7 +302,7 @@ cmd_ow() {
     info "booting open-wearables backend (migrations + seeds + API on \${API_PORT:-8000})"
     info "svix webhook registration may retry/skip — no svix server in this stack (non-fatal)"
     cd "$OW_BACKEND_DIR"
-    exec bash scripts/start/app.sh
+    ENVIRONMENT=production exec bash scripts/start/app.sh
 }
 
 cmd_ow_worker() {

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -78,7 +78,7 @@ open_wearables_listener_is_managed() {
     local pid=$1 parent command
     while [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ]; do
         command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
-        [[ "$command" == *"fastapi dev app/main.py"* ]] && return 0
+        [[ "$command" == *"fastapi dev app/main.py"* || "$command" == *"fastapi run app/main.py"* ]] && return 0
         parent="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
         [ "$parent" != "$pid" ] || break
         pid="$parent"

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -75,11 +75,15 @@ open_wearables_listener_pid() {
 }
 
 open_wearables_listener_is_managed() {
-    local pid=$1 parent command process_cwd
+    local pid=$1 parent command process_cwd listener_pid
+    while read -r listener_pid; do
+        [ "$listener_pid" = "$pid" ] && break
+    done < <(lsof -nP -iTCP:"${API_PORT:-8000}" -sTCP:LISTEN -t 2>/dev/null)
+    [ "${listener_pid:-}" = "$pid" ] || return 1
     while [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ]; do
         command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
         process_cwd="$(lsof -n -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ { sub(/^n/, ""); print; exit }')"
-        [[ "$command" == *"fastapi dev app/main.py"* || "$command" == *"fastapi run app/main.py"* ]] \
+        [[ "$command" == *"fastapi run app/main.py"* ]] \
             && [ "$process_cwd" = "$REPO_ROOT/vendor/open-wearables/backend" ] && return 0
         parent="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
         [ "$parent" != "$pid" ] || break

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -75,10 +75,12 @@ open_wearables_listener_pid() {
 }
 
 open_wearables_listener_is_managed() {
-    local pid=$1 parent command
+    local pid=$1 parent command process_cwd
     while [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ]; do
         command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
-        [[ "$command" == *"fastapi dev app/main.py"* || "$command" == *"fastapi run app/main.py"* ]] && return 0
+        process_cwd="$(lsof -n -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ { sub(/^n/, ""); print; exit }')"
+        [[ "$command" == *"fastapi dev app/main.py"* || "$command" == *"fastapi run app/main.py"* ]] \
+            && [ "$process_cwd" = "$REPO_ROOT/vendor/open-wearables/backend" ] && return 0
         parent="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
         [ "$parent" != "$pid" ] || break
         pid="$parent"

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -107,6 +107,8 @@ start_open_wearables() {
     for _ in 1 2 3 4 5 6 7 8 9 10; do
         listener_pid="$(open_wearables_listener_pid)"
         if [ -n "$listener_pid" ]; then
+            open_wearables_listener_is_managed "$listener_pid" \
+                || die "Open Wearables port ${API_PORT:-8000} is already owned by pid $listener_pid"
             printf '%s\n' "$listener_pid" >"$OW_PID"
             info "Open Wearables listener adopted (pid $listener_pid)"
             return

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -128,7 +128,7 @@ start_open_wearables() {
 }
 
 stop_process() {
-    local name=$1 pid_file=$2 pid child process_pid still_running
+    local name=$1 pid_file=$2 expected_pid=${3:-} pid child process_pid still_running
     local -a pids
     if ! pid_running "$pid_file"; then
         rm -f "$pid_file"
@@ -136,6 +136,11 @@ stop_process() {
         return
     fi
     pid="$(<"$pid_file")"
+    if [ -n "$expected_pid" ] && [ "$pid" != "$expected_pid" ]; then
+        rm -f "$pid_file"
+        info "$name stopped without terminating a replaced pid"
+        return
+    fi
     pids=("$pid")
     while read -r child; do
         [ -n "$child" ] && pids+=("$child")
@@ -169,7 +174,7 @@ stop_open_wearables() {
             return
         fi
     fi
-    stop_process "Open Wearables" "$OW_PID"
+    stop_process "Open Wearables" "$OW_PID" "$pid"
 }
 
 load_runtime_env() {

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -55,6 +55,65 @@ start_process() {
     info "$name started (pid $(<"$pid_file"))"
 }
 
+open_wearables_listener_pid() {
+    local -a pids
+    local pid parent candidate
+    while read -r pid; do
+        [ -n "$pid" ] && pids+=("$pid")
+    done < <(lsof -nP -iTCP:"${API_PORT:-8000}" -sTCP:LISTEN -t 2>/dev/null)
+    [ "${#pids[@]}" -gt 0 ] || return
+    for pid in "${pids[@]}"; do
+        parent="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+        for candidate in "${pids[@]}"; do
+            if [ "$parent" = "$candidate" ]; then
+                printf '%s\n' "$pid"
+                return
+            fi
+        done
+    done
+    printf '%s\n' "${pids[0]}"
+}
+
+open_wearables_listener_is_managed() {
+    local pid=$1 parent command
+    while [[ "$pid" =~ ^[0-9]+$ ]] && [ "$pid" -gt 1 ]; do
+        command="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+        [[ "$command" == *"fastapi dev app/main.py"* ]] && return 0
+        parent="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+        [ "$parent" != "$pid" ] || break
+        pid="$parent"
+    done
+    return 1
+}
+
+start_open_wearables() {
+    local listener_pid
+    if pid_running "$OW_PID"; then
+        info "Open Wearables already running (pid $(<"$OW_PID"))"
+        return
+    fi
+    listener_pid="$(open_wearables_listener_pid)"
+    if [ -n "$listener_pid" ]; then
+        open_wearables_listener_is_managed "$listener_pid" \
+            || die "Open Wearables port ${API_PORT:-8000} is already owned by pid $listener_pid"
+        printf '%s\n' "$listener_pid" >"$OW_PID"
+        info "Open Wearables listener adopted (pid $listener_pid)"
+        return
+    fi
+    start_process "Open Wearables" "$OW_PID" "$OW_LOG" \
+        "exec bash '$REPO_ROOT/scripts/dev_mac.sh' ow"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        listener_pid="$(open_wearables_listener_pid)"
+        if [ -n "$listener_pid" ]; then
+            printf '%s\n' "$listener_pid" >"$OW_PID"
+            info "Open Wearables listener adopted (pid $listener_pid)"
+            return
+        fi
+        sleep 1
+    done
+    die "Open Wearables did not open port ${API_PORT:-8000}; see $OW_LOG"
+}
+
 stop_process() {
     local name=$1 pid_file=$2 pid child process_pid still_running
     local -a pids
@@ -224,8 +283,7 @@ cmd_start() {
     bash "$REPO_ROOT/scripts/dev_mac.sh" services-start
     resolve_ow_api_key
     sync_hermes_ow_api_key
-    start_process "Open Wearables" "$OW_PID" "$OW_LOG" \
-        "exec bash '$REPO_ROOT/scripts/dev_mac.sh' ow"
+    start_open_wearables
     start_process "Open Wearables worker" "$WORKER_PID" "$WORKER_LOG" \
         "exec bash '$REPO_ROOT/scripts/dev_mac.sh' ow-worker"
     start_process "Open Wearables beat" "$BEAT_PID" "$BEAT_LOG" \

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -89,10 +89,15 @@ open_wearables_listener_is_managed() {
 }
 
 start_open_wearables() {
-    local listener_pid
+    local listener_pid pid
     if pid_running "$OW_PID"; then
-        info "Open Wearables already running (pid $(<"$OW_PID"))"
-        return
+        pid="$(<"$OW_PID")"
+        if open_wearables_listener_is_managed "$pid"; then
+            info "Open Wearables already running (pid $pid)"
+            return
+        fi
+        rm -f "$OW_PID"
+        info "discarded unmanaged Open Wearables pid $pid"
     fi
     listener_pid="$(open_wearables_listener_pid)"
     if [ -n "$listener_pid" ]; then

--- a/scripts/healthmes_local.sh
+++ b/scripts/healthmes_local.sh
@@ -150,6 +150,19 @@ stop_process() {
     info "$name stopped"
 }
 
+stop_open_wearables() {
+    local pid
+    if pid_running "$OW_PID"; then
+        pid="$(<"$OW_PID")"
+        if ! open_wearables_listener_is_managed "$pid"; then
+            rm -f "$OW_PID"
+            info "Open Wearables stopped without terminating an unmanaged pid"
+            return
+        fi
+    fi
+    stop_process "Open Wearables" "$OW_PID"
+}
+
 load_runtime_env() {
     set -a
     [ -f "$REPO_ROOT/.env" ] && source "$REPO_ROOT/.env"
@@ -315,7 +328,7 @@ stop_apps() {
     stop_process "HealthMes" "$HEALTHMES_PID"
     stop_process "Open Wearables beat" "$BEAT_PID"
     stop_process "Open Wearables worker" "$WORKER_PID"
-    stop_process "Open Wearables" "$OW_PID"
+    stop_open_wearables
 }
 
 cmd_stop() {

--- a/tests/api/test_connect.py
+++ b/tests/api/test_connect.py
@@ -20,7 +20,9 @@ from healthmes.api.auth import viewer_token
 from healthmes.api.connect import build_oura_card
 from healthmes.app import create_app
 from healthmes.calendars import creds
+from healthmes.calendars.runtime_status import record_calendar_status
 from healthmes.mcp_server.ow_client import OWClientError
+from healthmes.store.enums import CalendarSource
 
 TOKEN = "connect-page-api-token"
 APP_PASSWORD = "abcd-efgh-ijkl-mnop"
@@ -119,6 +121,19 @@ def test_mixed_state_renders_per_calendar(client, settings) -> None:
     assert "연결됨" in text and "미연결" in text
     assert "uv run healthmes connect google" in text
     assert "uv run healthmes connect icloud" not in text  # connected: no command
+
+
+def test_calendar_runtime_failures_stay_on_their_own_provider_card(client, settings) -> None:
+    connect_google(settings.data_dir)
+    connect_icloud(settings.data_dir)
+    record_calendar_status(
+        settings.data_dir, CalendarSource.GOOGLE, mode="mirror", error=RuntimeError()
+    )
+    text = client.get("/connect").text
+    assert "Google Calendar mirror" in text
+    assert "Google mirror 동기화 실패 (RuntimeError)" in text
+    assert "iCloud Calendar write" in text
+    assert "iCloud write 동기화 실패" not in text
 
 
 def test_gating_matches_viewer_pages(settings) -> None:

--- a/tests/api/test_connect.py
+++ b/tests/api/test_connect.py
@@ -132,7 +132,7 @@ def test_calendar_runtime_failures_stay_on_their_own_provider_card(client, setti
     text = client.get("/connect").text
     assert "Google Calendar mirror" in text
     assert "Google mirror 동기화 실패 (RuntimeError)" in text
-    assert "iCloud Calendar write" in text
+    assert "Apple/iCloud Calendar write" in text
     assert "iCloud write 동기화 실패" not in text
 
 

--- a/tests/api/test_privacy.py
+++ b/tests/api/test_privacy.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
+from healthmes.api.auth import viewer_token
 from healthmes.app import create_app
 
 
@@ -16,3 +17,4 @@ def test_privacy_notice_is_public_without_the_api_token(settings) -> None:
     assert "sleep, recovery, cycles, workouts, and profile" in response.text
     assert "body measurements" not in response.text
     assert "private-api-token" not in response.text
+    assert viewer_token("private-api-token") not in response.text

--- a/tests/api/test_privacy.py
+++ b/tests/api/test_privacy.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from healthmes.app import create_app
+
+
+def test_privacy_notice_is_public_without_the_api_token(settings) -> None:
+    secured = settings.model_copy(update={"api_token": SecretStr("private-api-token")})
+
+    with TestClient(create_app(secured)) as client:
+        response = client.get("/privacy")
+
+    assert response.status_code == 200
+    assert "WHOOP" in response.text
+    assert "Calendar" in response.text
+    assert "sleep, recovery, cycles, workouts, and profile" in response.text
+    assert "body measurements" not in response.text
+    assert "private-api-token" not in response.text

--- a/tests/api/test_wiring.py
+++ b/tests/api/test_wiring.py
@@ -36,7 +36,7 @@ EXPECTED_PATHS = [
 
 
 def test_routers_list_covers_all_modules():
-    assert len(routers) == 17
+    assert len(routers) == 18
 
 
 def test_openapi_schema_generates_with_all_paths(client):

--- a/tests/calendars/test_runtime_status.py
+++ b/tests/calendars/test_runtime_status.py
@@ -20,3 +20,11 @@ def test_record_calendar_status_keeps_sync_failure_contained(tmp_path, monkeypat
     monkeypatch.setattr(runtime_status, "_status_lock", unavailable)
 
     record_calendar_status(tmp_path, CalendarSource.GOOGLE, mode="mirror")
+
+
+def test_read_calendar_status_ignores_non_utf8_contents(tmp_path) -> None:
+    path = tmp_path / "runtime" / "calendar-status.json"
+    path.parent.mkdir()
+    path.write_bytes(b"\xff")
+
+    assert read_calendar_status(tmp_path) == {}

--- a/tests/calendars/test_runtime_status.py
+++ b/tests/calendars/test_runtime_status.py
@@ -1,0 +1,12 @@
+from healthmes.calendars.runtime_status import read_calendar_status, record_calendar_status
+from healthmes.store.enums import CalendarSource
+
+
+def test_record_calendar_status_preserves_each_provider_entry(tmp_path) -> None:
+    record_calendar_status(tmp_path, CalendarSource.GOOGLE, mode="mirror")
+    record_calendar_status(tmp_path, CalendarSource.CALDAV, mode="write")
+
+    status = read_calendar_status(tmp_path)
+
+    assert status[CalendarSource.GOOGLE.value]["mode"] == "mirror"
+    assert status[CalendarSource.CALDAV.value]["mode"] == "write"

--- a/tests/calendars/test_runtime_status.py
+++ b/tests/calendars/test_runtime_status.py
@@ -1,3 +1,4 @@
+import healthmes.calendars.runtime_status as runtime_status
 from healthmes.calendars.runtime_status import read_calendar_status, record_calendar_status
 from healthmes.store.enums import CalendarSource
 
@@ -10,3 +11,12 @@ def test_record_calendar_status_preserves_each_provider_entry(tmp_path) -> None:
 
     assert status[CalendarSource.GOOGLE.value]["mode"] == "mirror"
     assert status[CalendarSource.CALDAV.value]["mode"] == "write"
+
+
+def test_record_calendar_status_keeps_sync_failure_contained(tmp_path, monkeypatch) -> None:
+    def unavailable(_path):
+        raise OSError("unavailable")
+
+    monkeypatch.setattr(runtime_status, "_status_lock", unavailable)
+
+    record_calendar_status(tmp_path, CalendarSource.GOOGLE, mode="mirror")

--- a/tests/calendars/test_sleep_cli.py
+++ b/tests/calendars/test_sleep_cli.py
@@ -34,3 +34,21 @@ def test_sleep_reconcile_cli_prints_only_the_redacted_preview(
     # Then
     assert result == 0
     assert json.loads(capsys.readouterr().out) == preview
+
+
+def test_sleep_recheck_cli_prints_a_read_only_diagnostic(settings, monkeypatch, capsys) -> None:
+    result_payload = {
+        "status": "read_only_recheck",
+        "outcome": "no_provider_record",
+        "calendar_write": "unchanged",
+    }
+
+    async def fake_recheck(_settings, night_start):
+        assert night_start == dt.date(2026, 7, 26)
+        return result_payload
+
+    monkeypatch.setattr(cli, "_cli_settings", lambda: settings)
+    monkeypatch.setattr(cli, "recheck_sleep_night", fake_recheck)
+
+    assert cli.main(["sleep", "recheck", "--dry-run", "--date", "2026-07-26"]) == 0
+    assert json.loads(capsys.readouterr().out) == result_payload

--- a/tests/calendars/test_sleep_recheck.py
+++ b/tests/calendars/test_sleep_recheck.py
@@ -1,0 +1,71 @@
+from datetime import date
+
+import pytest
+
+from healthmes.calendars.sleep_recheck import recheck_sleep_night
+from healthmes.mcp_server.ow_client import OWAuthError, OWClientError, OWConfigurationError
+
+
+class FakeReader:
+    def __init__(self, rows_by_date, *, connections=None, error=None):
+        self.rows_by_date = rows_by_date
+        self.connections = connections if connections is not None else [
+            {"provider": "oura", "status": "active"}
+        ]
+        self.error = error
+
+    async def list_users(self, **_kwargs):
+        return {"items": [{"id": "only-user"}]}
+
+    async def get_connections(self, _user_id):
+        if self.error is not None:
+            raise self.error
+        return self.connections
+
+    async def collect_sleep_summaries(self, _user_id, start_date, _end_date):
+        if self.error is not None:
+            raise self.error
+        return self.rows_by_date.get(start_date, [])
+
+
+def valid_row(day: str) -> dict[str, object]:
+    return {
+        "date": day,
+        "source": {"provider": "oura"},
+        "start_time": f"{day}T22:00:00+00:00",
+        "end_time": f"{day}T23:00:00+00:00",
+        "duration_minutes": 60,
+        "time_in_bed_minutes": 60,
+    }
+
+
+@pytest.mark.anyio
+async def test_recheck_reports_date_basis_mismatch_without_writing(settings) -> None:
+    result = await recheck_sleep_night(
+        settings,
+        date(2026, 7, 26),
+        client=FakeReader({"2026-07-27": [valid_row("2026-07-27")]}),
+    )
+    assert result["outcome"] == "date_basis_mismatch"
+    assert result["calendar_write"] == "unchanged"
+    assert result["windows"] == {
+        "night_start": {"start": "2026-07-26", "end": "2026-07-27"},
+        "oura_summary": {"start": "2026-07-27", "end": "2026-07-28"},
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("error", "outcome"),
+    [
+        (OWAuthError("no"), "authentication_failure"),
+        (OWConfigurationError("no"), "authentication_failure"),
+        (OWClientError("no"), "api_transport_failure"),
+    ],
+)
+async def test_recheck_redacts_client_failures(settings, error, outcome) -> None:
+    result = await recheck_sleep_night(
+        settings, date(2026, 7, 26), client=FakeReader({}, error=error)
+    )
+    assert result["outcome"] == outcome
+    assert result["calendar_write"] == "unchanged"

--- a/tests/calendars/test_sleep_recheck.py
+++ b/tests/calendars/test_sleep_recheck.py
@@ -55,6 +55,19 @@ async def test_recheck_reports_date_basis_mismatch_without_writing(settings) -> 
 
 
 @pytest.mark.anyio
+async def test_recheck_reports_a_selectable_night_without_writing(settings) -> None:
+    result = await recheck_sleep_night(
+        settings,
+        date(2026, 7, 26),
+        client=FakeReader({"2026-07-26": [valid_row("2026-07-26")]}),
+    )
+
+    assert result["outcome"] == "ok"
+    assert result["selected_date"] == "2026-07-26"
+    assert result["calendar_write"] == "unchanged"
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("client", "outcome"),
     [

--- a/tests/calendars/test_sleep_recheck.py
+++ b/tests/calendars/test_sleep_recheck.py
@@ -56,6 +56,38 @@ async def test_recheck_reports_date_basis_mismatch_without_writing(settings) -> 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
+    ("client", "outcome"),
+    [
+        (
+            FakeReader({}, connections=[{"provider": "oura", "status": "error"}]),
+            "vendor_sync_failure",
+        ),
+        (FakeReader({}), "no_provider_record"),
+        (
+            FakeReader(
+                {
+                    "2026-07-26": [
+                        {
+                            "date": "2026-07-26",
+                            "source": {"provider": "oura"},
+                            "duration_minutes": 60,
+                            "time_in_bed_minutes": 60,
+                        }
+                    ]
+                }
+            ),
+            "incomplete_record",
+        ),
+    ],
+)
+async def test_recheck_reports_non_transfer_diagnostics(settings, client, outcome) -> None:
+    result = await recheck_sleep_night(settings, date(2026, 7, 26), client=client)
+    assert result["outcome"] == outcome
+    assert result["calendar_write"] == "unchanged"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
     ("error", "outcome"),
     [
         (OWAuthError("no"), "authentication_failure"),

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -138,11 +138,15 @@ def test_local_runtime_starts_and_supervises_open_wearables_beat() -> None:
     start_body = _function_body(local_text, "cmd_start")
     daemon_body = _function_body(local_text, "cmd_daemon")
     stop_body = _function_body(local_text, "stop_apps")
+    stop_ow_body = _function_body(local_text, "stop_open_wearables")
     status_body = _function_body(local_text, "cmd_status")
 
     assert 'start_process "Open Wearables beat"' in start_body
     assert '"$BEAT_PID"' in daemon_body
     assert 'stop_process "Open Wearables beat"' in stop_body
+    assert "stop_open_wearables" in stop_body
+    assert 'open_wearables_listener_is_managed "$pid"' in stop_ow_body
+    assert 'stop_process "Open Wearables" "$OW_PID"' in stop_ow_body
     assert 'service_status "Open Wearables beat"' in status_body
 
 

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -159,6 +159,8 @@ def test_local_runtime_adopts_the_open_wearables_listener_pid() -> None:
     guard_body = _function_body(text, "open_wearables_listener_is_managed")
     assert 'fastapi dev app/main.py' in guard_body
     assert 'fastapi run app/main.py' in guard_body
+    assert 'lsof -n -a -p "$pid" -d cwd -Fn' in guard_body
+    assert '"$REPO_ROOT/vendor/open-wearables/backend"' in guard_body
 
 
 def test_local_open_wearables_boots_a_single_production_listener() -> None:

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -163,8 +163,8 @@ def test_local_runtime_adopts_the_open_wearables_listener_pid() -> None:
     assert 'if open_wearables_listener_is_managed "$pid"' in body
     assert 'rm -f "$OW_PID"' in body
     guard_body = _function_body(text, "open_wearables_listener_is_managed")
-    assert 'fastapi dev app/main.py' in guard_body
     assert 'fastapi run app/main.py' in guard_body
+    assert 'lsof -nP -iTCP:"${API_PORT:-8000}" -sTCP:LISTEN -t' in guard_body
     assert 'lsof -n -a -p "$pid" -d cwd -Fn' in guard_body
     assert '"$REPO_ROOT/vendor/open-wearables/backend"' in guard_body
     assert body.count('open_wearables_listener_is_managed "$listener_pid"') == 2

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -156,6 +156,9 @@ def test_local_runtime_adopts_the_open_wearables_listener_pid() -> None:
     assert 'ps -o ppid= -p "$pid"' in listener_body
     assert 'printf \'%s\\n\' "$pid"' in listener_body
     assert "open_wearables_listener_is_managed" in body
+    guard_body = _function_body(text, "open_wearables_listener_is_managed")
+    assert 'fastapi dev app/main.py' in guard_body
+    assert 'fastapi run app/main.py' in guard_body
 
 
 def test_local_open_wearables_boots_a_single_production_listener() -> None:

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -170,6 +170,69 @@ def test_local_runtime_adopts_the_open_wearables_listener_pid() -> None:
     assert body.count('open_wearables_listener_is_managed "$listener_pid"') == 2
 
 
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_local_runtime_recovers_a_stale_pid_without_restarting_a_listener(tmp_path) -> None:
+    prelude = LOCAL_SCRIPT.read_text(encoding="utf-8").split(
+        '\ncase "${1:-}" in\n', 1
+    )[0]
+    harness = tmp_path / "runtime-harness.sh"
+    harness.write_text(
+        prelude
+        + r'''
+runtime_dir="$(mktemp -d)"
+sleep 30 & stale_pid=$!
+sleep 30 & managed_pid=$!
+trap 'kill "$stale_pid" "$managed_pid" 2>/dev/null || true' EXIT
+OW_PID="$runtime_dir/open-wearables.pid"
+OW_LOG="$runtime_dir/open-wearables.log"
+RUNTIME_DIR="$runtime_dir"
+printf '%s\n' "$stale_pid" >"$OW_PID"
+open_wearables_listener_is_managed() { [ "$1" = "$managed_pid" ]; }
+open_wearables_listener_pid() { printf '%s\n' "$managed_pid"; }
+start_process() { return 1; }
+start_open_wearables
+start_open_wearables
+test "$(<"$OW_PID")" = "$managed_pid"
+''',
+        encoding="utf-8",
+    )
+
+    subprocess.run(["bash", str(harness)], check=True)
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_local_runtime_recovers_after_a_temporary_listener_gap(tmp_path) -> None:
+    prelude = LOCAL_SCRIPT.read_text(encoding="utf-8").split(
+        '\ncase "${1:-}" in\n', 1
+    )[0]
+    harness = tmp_path / "recovery-harness.sh"
+    harness.write_text(
+        prelude
+        + r'''
+runtime_dir="$(mktemp -d)"
+sleep 30 & managed_pid=$!
+trap 'kill "$managed_pid" 2>/dev/null || true' EXIT
+OW_PID="$runtime_dir/open-wearables.pid"
+OW_LOG="$runtime_dir/open-wearables.log"
+RUNTIME_DIR="$runtime_dir"
+listener_ready=false
+open_wearables_listener_is_managed() { [ "$1" = "$managed_pid" ]; }
+open_wearables_listener_pid() {
+    if [ "$listener_ready" = true ]; then
+        printf '%s\n' "$managed_pid"
+    fi
+}
+start_process() { listener_ready=true; }
+sleep() { :; }
+start_open_wearables
+test "$(<"$OW_PID")" = "$managed_pid"
+''',
+        encoding="utf-8",
+    )
+
+    subprocess.run(["bash", str(harness)], check=True)
+
+
 def test_local_open_wearables_boots_a_single_production_listener() -> None:
     body = _function_body(SCRIPT.read_text(encoding="utf-8"), "cmd_ow")
     assert "ENVIRONMENT=production exec bash scripts/start/app.sh" in body

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -146,7 +146,7 @@ def test_local_runtime_starts_and_supervises_open_wearables_beat() -> None:
     assert 'stop_process "Open Wearables beat"' in stop_body
     assert "stop_open_wearables" in stop_body
     assert 'open_wearables_listener_is_managed "$pid"' in stop_ow_body
-    assert 'stop_process "Open Wearables" "$OW_PID"' in stop_ow_body
+    assert 'stop_process "Open Wearables" "$OW_PID" "$pid"' in stop_ow_body
     assert 'service_status "Open Wearables beat"' in status_body
 
 

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -161,6 +161,7 @@ def test_local_runtime_adopts_the_open_wearables_listener_pid() -> None:
     assert 'fastapi run app/main.py' in guard_body
     assert 'lsof -n -a -p "$pid" -d cwd -Fn' in guard_body
     assert '"$REPO_ROOT/vendor/open-wearables/backend"' in guard_body
+    assert body.count('open_wearables_listener_is_managed "$listener_pid"') == 2
 
 
 def test_local_open_wearables_boots_a_single_production_listener() -> None:

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -108,7 +108,7 @@ def test_local_start_syncs_resolved_ow_key_into_hermes_before_apps() -> None:
         "sync_hermes_ow_api_key"
     )
     assert start_body.index("sync_hermes_ow_api_key") < start_body.index(
-        'start_process "Open Wearables"'
+        "start_open_wearables"
     )
 
 
@@ -144,6 +144,23 @@ def test_local_runtime_starts_and_supervises_open_wearables_beat() -> None:
     assert '"$BEAT_PID"' in daemon_body
     assert 'stop_process "Open Wearables beat"' in stop_body
     assert 'service_status "Open Wearables beat"' in status_body
+
+
+def test_local_runtime_adopts_the_open_wearables_listener_pid() -> None:
+    text = LOCAL_SCRIPT.read_text(encoding="utf-8")
+    body = _function_body(text, "start_open_wearables")
+    listener_body = _function_body(text, "open_wearables_listener_pid")
+    assert "open_wearables_listener_pid" in body
+    assert 'printf \'%s\\n\' "$listener_pid" >"$OW_PID"' in body
+    assert 'Open Wearables port ${API_PORT:-8000} is already owned' in body
+    assert 'ps -o ppid= -p "$pid"' in listener_body
+    assert 'printf \'%s\\n\' "$pid"' in listener_body
+    assert "open_wearables_listener_is_managed" in body
+
+
+def test_local_open_wearables_boots_a_single_production_listener() -> None:
+    body = _function_body(SCRIPT.read_text(encoding="utf-8"), "cmd_ow")
+    assert "ENVIRONMENT=production exec bash scripts/start/app.sh" in body
 
 
 def test_manual_mac_runtime_exposes_open_wearables_beat_target() -> None:

--- a/tests/glue/test_dev_mac.py
+++ b/tests/glue/test_dev_mac.py
@@ -160,6 +160,8 @@ def test_local_runtime_adopts_the_open_wearables_listener_pid() -> None:
     assert 'ps -o ppid= -p "$pid"' in listener_body
     assert 'printf \'%s\\n\' "$pid"' in listener_body
     assert "open_wearables_listener_is_managed" in body
+    assert 'if open_wearables_listener_is_managed "$pid"' in body
+    assert 'rm -f "$OW_PID"' in body
     guard_body = _function_body(text, "open_wearables_listener_is_managed")
     assert 'fastapi dev app/main.py' in guard_body
     assert 'fastapi run app/main.py' in guard_body

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -96,7 +96,7 @@ class TestMcpWiring:
             response = client.post("/mcp", json=_MCP_INITIALIZE, headers=_MCP_HEADERS)
 
             assert response.status_code == 200
-            assert response.headers.get("mcp-session-id")
+            assert response.headers.get("mcp-session-id") is None
             assert '"serverInfo"' in response.text
             assert '"healthmes"' in response.text
 


### PR DESCRIPTION
## Summary
- supervise only an owned production Open Wearables socket listener and defend stale or replaced PID files
- show Apple/iCloud writes, Google mirroring, and Open Wearables independently
- add read-only named-night sleep rechecks with explicit outcome and date-window diagnostics
- publish a public WHOOP OAuth disclosure without viewer credentials

## Verification
- full suite: 1387 passed, 4 skipped
- latest focused lifecycle, status, CLI, and API checks: 67 passed
- manual recovery smoke checks: stale PID recovered; unmanaged PID was not terminated
- real WHOOP dogfood: workout scope authorization and sync completed; no Calendar action was issued

Closes #126