### PR TITLE
Restore actual-sleep MCP preview contract

### DIFF
--- a/config/hermes-config.yaml.tmpl
+++ b/config/hermes-config.yaml.tmpl
@@ -13,6 +13,11 @@
 # $HERMES_HOME/cron/jobs.json and are registered by scripts/bootstrap.py
 # against vendor/hermes-agent/cron/jobs.py::create_job.
 
+# The CLI snapshots the tool registry after this bounded discovery wait.
+# Local MCP startup can exceed the vendor's 1.5-second default, especially
+# when a stdio server initializes alongside the HealthMes HTTP transport.
+mcp_discovery_timeout: 20
+
 {%- if hermes_model or hermes_provider %}
 # LLM selection — optional. Omit to let the vendor auto-default (Anthropic).
 # Any plugin under vendor/hermes-agent/plugins/model-providers/ works here

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -240,7 +240,7 @@ Running the gateway natively (verified live on macOS with dummy creds):
 ```bash
 cd vendor/hermes-agent && \
   HERMES_HOME=... UV_PROJECT_ENVIRONMENT=../../data/hermes-venv \
-  uv run --frozen --no-dev --extra messaging hermes gateway run
+  uv run --frozen --no-dev --extra messaging --extra mcp hermes gateway run
 ```
 
 Two caveats from live verification: (1) if a supervised hermes service is
@@ -259,7 +259,7 @@ terminal agent has the identical MCP tools and skills as the Telegram bot:
 ```bash
 cd vendor/hermes-agent && \
   HERMES_HOME=~/.hermes UV_PROJECT_ENVIRONMENT=../../data/hermes-venv \
-  uv run --frozen --no-dev --extra messaging hermes            # interactive
+  uv run --frozen --no-dev --extra messaging --extra mcp hermes # interactive
 # one-shot:
 #   ... hermes chat -q "How was my sleep this week?"
 ```

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -120,7 +120,7 @@ open http://localhost:8100/docs         # REST playground (OpenAPI)
   ```bash
   cd vendor/hermes-agent && \
     HERMES_HOME=~/.hermes UV_PROJECT_ENVIRONMENT=../../data/hermes-venv \
-    uv run --frozen --no-dev --extra messaging hermes chat -q \
+    uv run --frozen --no-dev --extra messaging --extra mcp hermes chat -q \
     "오늘 무리해도 돼? get_daily_readiness_context로 근거 보여줘"
   ```
 

--- a/healthmes/mcp_server/server.py
+++ b/healthmes/mcp_server/server.py
@@ -47,7 +47,7 @@ import os
 import re
 import uuid
 from collections.abc import Awaitable, Callable, Iterable, Mapping
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 from fastmcp import FastMCP
@@ -66,16 +66,20 @@ from healthmes.calendars.adjustments import (
     digest_reply_handle,
     issue_reply_handle,
 )
-from healthmes.calendars.base import HealthmesEventKind
+from healthmes.calendars.approval import ApprovalCalendar, calendar_approval_target
+from healthmes.calendars.base import CalendarError, HealthmesEventKind
 from healthmes.calendars.google import GoogleCalendarBackend
 from healthmes.calendars.intake import intake_revision
+from healthmes.calendars.jobs import _build_backend, write_source
 from healthmes.calendars.sleep_context import (
     actual_sleep_context_with_source_ref,
     actual_sleep_observation_context,
     actual_sleep_violation,
 )
 from healthmes.calendars.sleep_observation import ActualSleepObservation
+from healthmes.calendars.sleep_proposals import prepare_sleep_proposal
 from healthmes.calendars.sleep_source import (
+    select_actual_sleep_rows,
     select_actual_sleep_rows_with_source,
 )
 from healthmes.config import Settings, get_settings, system_timezone
@@ -3271,6 +3275,142 @@ def resolve_schedule_proposal(
                 ),
             },
         }
+
+
+@mcp.tool
+async def prepare_actual_sleep_calendar_update(
+    date: str | None = None,
+    date_basis: Literal["night_start", "oura_summary"] | None = None,
+) -> dict[str, Any]:
+    """Prepare an Oura actual-sleep Calendar update without writing it.
+
+    The preview is based on fresh Oura and Calendar evidence. It creates no
+    Calendar event: local browser confirmation remains required for the
+    existing verified apply path.
+    """
+    requested_date = _parse_date(date, "date")
+    resolved_date_basis = date_basis or (
+        "oura_summary" if date is None else "night_start"
+    )
+    settings = _active_settings()
+    source = write_source(settings)
+    if source is None:
+        raise ToolError(
+            "Google 또는 iCloud Calendar가 연결되지 않아 수면 업데이트를 준비할 수 없습니다."
+        )
+    try:
+        backend = _build_backend(settings, source)
+        user_id = await _resolve_user_id()
+        reader = get_ow_client()
+        target_date = await _resolve_sleep_summary_date(
+            reader,
+            user_id,
+            requested_date,
+            _local_timezone(),
+            resolved_date_basis,
+        )
+        with _store_session() as session:
+            proposal = await prepare_sleep_proposal(
+                target_date=target_date,
+                calendar_source=source,
+                reader=reader,
+                user_id=user_id,
+                session=session,
+                calendar=ApprovalCalendar(
+                    backend,
+                    calendar_approval_target(settings, source),
+                    settings.public_base_url,
+                ),
+            )
+            snapshot = proposal.snapshot
+            preview_keys = (
+                "status",
+                "action",
+                "calendar",
+                "local_date",
+                "summary",
+                "start",
+                "wake_time",
+                "duration_minutes",
+                "time_in_bed_minutes",
+                "non_sleep_minutes",
+                "source",
+                "planned_sleep_replacements",
+                "segments",
+                "segment_count",
+                "stale_segment_removals",
+                "reason",
+            )
+            preview = {
+                key: snapshot[key] for key in preview_keys if key in snapshot
+            }
+            timezone = _local_timezone()
+            if "start" in snapshot:
+                preview["start_local"] = dt.datetime.fromisoformat(
+                    str(snapshot["start"])
+                ).astimezone(timezone).isoformat()
+            if "wake_time" in snapshot:
+                preview["wake_time_local"] = dt.datetime.fromisoformat(
+                    str(snapshot["wake_time"])
+                ).astimezone(timezone).isoformat()
+            preview["timezone"] = str(timezone)
+            preview["requested_date"] = requested_date.isoformat()
+            preview["oura_summary_date"] = target_date.isoformat()
+            preview["date_basis"] = resolved_date_basis
+            proposal_id = str(proposal.id)
+            proposal_status = _enum_value(proposal.status)
+            expires_at = _iso_utc(proposal.expires_at)
+            expires_at_local = _ensure_utc_dt(proposal.expires_at).astimezone(
+                timezone
+            ).isoformat()
+    except (CalendarError, OWClientError, LookupError) as exc:
+        raise ToolError(
+            f"수면 Calendar preview 준비 실패: {type(exc).__name__}"
+        ) from exc
+
+    pending = proposal_status == "pending"
+    return {
+        "status": "preview_ready" if pending else proposal_status,
+        "proposal_id": proposal_id,
+        "proposal_status": proposal_status,
+        "calendar_write": (
+            "requires_local_browser_confirmation" if pending else "unchanged"
+        ),
+        "review_url": (
+            f"http://127.0.0.1:{settings.port}/sleep?proposal={proposal_id}"
+        ),
+        "expires_at": expires_at,
+        "expires_at_local": expires_at_local,
+        "preview": preview,
+    }
+
+
+async def _resolve_sleep_summary_date(
+    reader: Any,
+    user_id: str,
+    requested_date: dt.date,
+    timezone: dt.tzinfo,
+    date_basis: Literal["night_start", "oura_summary"],
+) -> dt.date:
+    """Resolve a user-visible night start into Oura's summary date."""
+    if date_basis == "oura_summary":
+        return requested_date
+    next_date = requested_date + dt.timedelta(days=1)
+    rows = await reader.collect_sleep_summaries(
+        user_id,
+        requested_date.isoformat(),
+        (requested_date + dt.timedelta(days=2)).isoformat(),
+    )
+    next_observation = select_actual_sleep_rows(rows, next_date)
+    if isinstance(next_observation, ActualSleepObservation):
+        start_date = _ensure_utc_dt(next_observation.start_at).astimezone(
+            timezone
+        ).date()
+        if start_date == requested_date:
+            return next_date
+    raise ToolError(
+        f"{requested_date.isoformat()} 밤에 시작한 Oura 주 수면을 찾지 못했습니다."
+    )
 
 
 @mcp.tool

--- a/plugins/healthmes-routing/__init__.py
+++ b/plugins/healthmes-routing/__init__.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+
+_SLEEP = re.compile(r"(?:oura|오우라|수면|잠)", re.IGNORECASE)
+_CALENDAR = re.compile(r"(?:calendar|캘린더)", re.IGNORECASE)
+_UPDATE = re.compile(r"(?:sync|update|reflect|동기화|업데이트|반영|기록)", re.IGNORECASE)
+_EXPLICIT_DATE = re.compile(
+    r"(?:\b\d{4}-\d{1,2}-\d{1,2}\b|\b\d{1,2}[/-]\d{1,2}\b|\d{1,2}월\s*\d{1,2}일)"
+)
+_EXPLICIT_TIMES = re.compile(
+    r"\b(?:[01]?\d|2[0-3]):[0-5]\d\s*(?:→|->|~|–|—|-)\s*"
+    r"(?:[01]?\d|2[0-3]):[0-5]\d\b"
+)
+_SUMMARY_DATE = re.compile(r"(?:oura\s*(?:summary|요약)|summary\s*date|요약일)", re.IGNORECASE)
+
+
+def _sleep_calendar_context(user_message: str) -> str | None:
+    if not (
+        _SLEEP.search(user_message)
+        and _CALENDAR.search(user_message)
+        and _UPDATE.search(user_message)
+    ):
+        return None
+    if _EXPLICIT_TIMES.search(user_message) or _SUMMARY_DATE.search(user_message):
+        date_basis = "oura_summary"
+    elif _EXPLICIT_DATE.search(user_message):
+        date_basis = "night_start"
+    else:
+        date_basis = "oura_summary"
+    return (
+        "[HealthMes deterministic route]\n"
+        "This turn is an explicit request to prepare an Oura actual-sleep Calendar "
+        "update. Ignore any earlier conversational claim about Calendar authentication; "
+        "do not infer connection state from memory or a browser login page. Call the "
+        "currently registered HealthMes MCP tool whose basename is "
+        "`prepare_actual_sleep_calendar_update` now and use its result as the only "
+        "authority. Never answer from an earlier tool result. A previous proposal_id, "
+        "review_url, status, preview, or expiry is stale for this turn. If this turn "
+        "does not produce a fresh tool result, do not claim a preview or link was "
+        "refreshed. Do not use browser automation, raw Oura lookup, or a planner tool. "
+        f'Call it with date_basis="{date_basis}". '
+        "Use night_start for a plain user-named date; it must not substitute a same-day "
+        "summary when no next-day sleep started on that date. Use oura_summary when the "
+        "user identifies a session by exact start/wake times or explicitly names an Oura "
+        "summary date. Pass the date the user names. Return the preview and local "
+        "review_url, and state that Calendar is unchanged until local browser "
+        "confirmation. If the tool itself reports a connection error or no matching "
+        "night, report that error directly without calling a clarification tool or "
+        "asking a follow-up; never preemptively claim authentication is missing."
+    )
+
+
+def _inject_route(user_message: str = "", **kwargs):
+    context = _sleep_calendar_context(user_message)
+    return {"context": context} if context else None
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_llm_call", _inject_route)

--- a/plugins/healthmes-routing/plugin.yaml
+++ b/plugins/healthmes-routing/plugin.yaml
@@ -1,0 +1,5 @@
+name: healthmes-routing
+version: 0.1.0
+description: Route explicit HealthMes sleep Calendar requests in long-lived Hermes sessions.
+provides_hooks:
+  - pre_llm_call

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -561,6 +561,45 @@ def install_skills(repo_root: Path, hermes_home: Path, plan: Plan) -> list[Path]
     return installed
 
 
+def discover_plugin_dirs(repo_root: Path) -> list[Path]:
+    plugins_root = repo_root / "plugins"
+    if not plugins_root.is_dir():
+        return []
+    return sorted(
+        child
+        for child in plugins_root.iterdir()
+        if child.is_dir()
+        and (child / "plugin.yaml").is_file()
+        and (child / "__init__.py").is_file()
+    )
+
+
+def install_plugins(repo_root: Path, hermes_home: Path, plan: Plan) -> list[Path]:
+    plugins_home = hermes_home / "plugins"
+    installed: list[Path] = []
+    for plugin_dir in discover_plugin_dirs(repo_root):
+        dest = plugins_home / plugin_dir.name
+        if dest.exists() and not dest.is_dir():
+            plan.warn(
+                f"{dest} exists and is not a directory; leaving it untouched "
+                f"(remove it manually to let bootstrap manage this plugin)"
+            )
+            continue
+        if dest.is_dir() and _dir_snapshot(dest) == _dir_snapshot(plugin_dir):
+            plan.act(f"keep plugin copy {dest} (content up to date)")
+            installed.append(dest)
+            continue
+        action = "resync" if dest.is_dir() else "copy"
+        plan.act(f"{action} plugin {plugin_dir} -> {dest}")
+        if not plan.dry_run:
+            if dest.is_dir():
+                shutil.rmtree(dest)
+            plugins_home.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(plugin_dir, dest)
+        installed.append(dest)
+    return installed
+
+
 # ---------------------------------------------------------------------------
 # Briefing snapshot script (docs/PLAN.md section 4 `script:` context injection)
 # ---------------------------------------------------------------------------
@@ -1153,6 +1192,7 @@ def run(args: argparse.Namespace) -> int:
 
     write_config(hermes_home, rendered, plan)
     install_skills(REPO_ROOT, hermes_home, plan)
+    install_plugins(REPO_ROOT, hermes_home, plan)
     # Before cron registration: the jobs reference this script by name and
     # create_job's lifecycle guard reads it from $HERMES_HOME/scripts/.
     install_snapshot_script(hermes_home, context, plan)

--- a/skills/healthmes-planner/SKILL.md
+++ b/skills/healthmes-planner/SKILL.md
@@ -84,6 +84,10 @@ Morning calendar-nudge tools may also be present on the `healthmes` server:
 - Food, medication, or symptom capture → use the `healthmes-capture` skill.
 - Pure data questions ("how did I sleep?") → answer directly with the MCP
   tools; no proposals, but still record a decision if you give advice.
+- Actual Oura sleep-time Calendar sync/update requests → use
+  `healthmes-sleep` and
+  `mcp__healthmes__prepare_actual_sleep_calendar_update`. Do not turn actual
+  sleep mirroring into a task block or recovery-based schedule adjustment.
 
 ## Core workflow: goal dump → tasks → placement → confirm → record
 

--- a/skills/healthmes-sleep/SKILL.md
+++ b/skills/healthmes-sleep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: healthmes-sleep
-description: Interpret recent sleep and readiness evidence to answer whether today's work or training intensity should be reconsidered. Use for questions about last night's sleep, accumulated sleep debt, recovery after poor sleep, or whether sleep evidence is strong enough to change today's plan.
+description: Interpret recent sleep and readiness evidence, or prepare a confirmed Oura actual-sleep Calendar update. Use for questions about last night's sleep, accumulated sleep debt, recovery after poor sleep, whether sleep evidence is strong enough to change today's plan, or requests to sync/update actual sleep time in Calendar.
 ---
 
 # HealthMes Sleep
@@ -13,10 +13,21 @@ directly.
 
 - Read data only through registered MCP tools. Never call HealthMes or
   open-wearables REST endpoints directly.
+- If the required HealthMes MCP tool is missing or unavailable, or its call
+  fails, fail closed: return `insufficient_data` and state that live HealthMes
+  evidence is unavailable. Do not search session memory or local files, call
+  REST endpoints, or reuse a past observation as current evidence. Do not
+  record a decision from substituted or stale evidence.
 - Start with `mcp__healthmes__get_daily_readiness_context` for the target
   date. It already interprets seven-night sleep debt, last-night sleep score,
   nocturnal HRV versus the personal baseline, stress, charge, yesterday's
   load, and overall confidence.
+- If the user asks to sync or update the actual Oura sleep time in Calendar,
+  call `mcp__healthmes__prepare_actual_sleep_calendar_update` directly. Do not
+  route that request through `healthmes-planner`,
+  `mcp__healthmes__propose_schedule_blocks`, or a raw sleep-summary lookup.
+  Present the returned preview and `review_url`; Calendar remains unchanged
+  until the user opens that local link on this Mac and confirms it.
 - Use `mcp__open_wearables__get_sleep_summary` only when basic sleep timing,
   duration, or source helps explain the interpreted context. It does not expose
   stages, efficiency, HRV, respiration, or SpO2. Defer those reviews instead of
@@ -36,7 +47,8 @@ directly.
 ## Boundaries
 
 - Use this skill for questions such as "How did I sleep?", "Should I push
-  hard today?", or "Is my recent sleep poor enough to change today's plan?"
+  hard today?", "Is my recent sleep poor enough to change today's plan?", or
+  "Oura 수면 시간 업데이트하고 캘린더에도 반영해줘."
 - Do not screen for sleep apnea, diagnose insomnia, predict injury, prescribe
   treatment, or interpret medication effects. Recommend professional care
   when the user asks for medical conclusions or reports concerning symptoms.
@@ -45,7 +57,37 @@ directly.
   require a separate behavior-impact skill with exposure data and explicit
   safeguards.
 - Do not replace `healthmes-planner`. This skill decides whether sleep evidence
-  justifies reconsideration; the planner owns any schedule proposal.
+  justifies reconsideration; the planner owns any daytime schedule proposal.
+  Actual-sleep Calendar mirroring is the exception and stays in this skill
+  through `mcp__healthmes__prepare_actual_sleep_calendar_update`.
+
+## Actual-sleep Calendar update
+
+For a request to update, sync, or reflect Oura sleep time in Calendar:
+
+1. Call `mcp__healthmes__prepare_actual_sleep_calendar_update` once with the
+   date the user names, or omit `date` for today's newly synced Oura record.
+   Use `date_basis="night_start"` for a plain named date such as "7월 29일
+   수면". Use `date_basis="oura_summary"` when the user identifies a session
+   by exact start/wake times or explicitly says Oura summary date. An omitted
+   date uses today's Oura summary. Never substitute a same-day summary when a
+   requested night-start record is missing. If the tool reports that no matching
+   night exists, state that result directly; do not call a clarification tool or
+   ask the user to choose a different record. Every new update or link-refresh
+   request requires a tool call in that turn. Never reuse a proposal id,
+   `review_url`, status, preview, or expiry from an earlier turn, and never claim
+   a link was refreshed without a fresh tool result.
+2. If `status` is `preview_ready`, summarize `preview.action`, start,
+   wake time, and duration using `preview.start_local`,
+   `preview.wake_time_local`, and `preview.timezone`, then give the returned
+   local `review_url`. Say clearly that Calendar has not changed yet and the
+   preview expires.
+3. If `status` is `noop`, say Calendar already matches the fresh Oura record.
+4. If `status` is `blocked`, report the returned safe reason and do not suggest
+   bypassing ownership or freshness checks.
+5. Never claim the Calendar was updated from this tool call. Only the local
+   review page can perform the existing explicit-confirmation and read-back
+   verified write.
 
 ## Judgment procedure
 

--- a/skills/healthmes-stress/SKILL.md
+++ b/skills/healthmes-stress/SKILL.md
@@ -17,6 +17,11 @@ diagnose a condition, infer a cause, or change a schedule directly.
 
 - Read data only through registered MCP tools. Never call HealthMes or
   open-wearables REST endpoints directly.
+- If a required HealthMes MCP tool is missing or unavailable, or its call
+  fails, fail closed: return `insufficient_data` and state that live HealthMes
+  evidence is unavailable. Do not search session memory or local files, call
+  REST endpoints, or reuse a past observation as current evidence. Do not
+  record a decision from substituted or stale evidence.
 - Start with `mcp__healthmes__get_stress_timeline` for the target date. It
   establishes the source, data resolution, coverage, confidence, and whether
   intraday interpretation is permitted.

--- a/tests/activity/test_adapters.py
+++ b/tests/activity/test_adapters.py
@@ -52,6 +52,8 @@ from healthmes.activity.service import (
 from healthmes.storage import update_retention_policy
 from healthmes.store import AppUsageSample, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 def _window_event(*, title: str, event_id: int | None = None) -> dict:
     event = {

--- a/tests/activity/test_aggregation_retention.py
+++ b/tests/activity/test_aggregation_retention.py
@@ -58,6 +58,8 @@ from healthmes.storage import (
 )
 from healthmes.store import AppUsageSample, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 def _interval_batch(
     records: list[AppIntervalRecord],

--- a/tests/activity/test_control_postgres.py
+++ b/tests/activity/test_control_postgres.py
@@ -47,6 +47,8 @@ from healthmes.config import Settings
 from healthmes.store import Base, WellnessEvent, create_db_engine
 from healthmes.store.session import get_session
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 @pytest.mark.parametrize(
     ("boundary_change", "expected_reason"),

--- a/tests/activity/test_ingest_privacy.py
+++ b/tests/activity/test_ingest_privacy.py
@@ -42,6 +42,8 @@ from healthmes.activity.service import (
 )
 from healthmes.store import RetentionPolicy, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 def _hour_batch(
     *,

--- a/tests/activity/test_resolver.py
+++ b/tests/activity/test_resolver.py
@@ -50,6 +50,8 @@ from healthmes.nutrition.intake_service import (
 from healthmes.nutrition.repository import persist_daily_confirmation
 from healthmes.store import CalendarEventMirror, CalendarSource, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 def _seed_activity(session) -> None:
     ingest_activity_batch(

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -17,6 +17,8 @@ from healthmes.activity.repository import (
 from healthmes.activity.service import ingest_activity_batch
 from healthmes.store import WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("legacy_api_fixture_clock")
+
 
 def _hour_record(
     *,

--- a/tests/api/test_app_usage.py
+++ b/tests/api/test_app_usage.py
@@ -16,6 +16,8 @@ from healthmes.activity.repository import (
 from healthmes.storage import update_retention_policy
 from healthmes.store import AppUsageSample, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("legacy_api_fixture_clock")
+
 
 def _batch(samples):
     return {

--- a/tests/api/test_intake_interactions.py
+++ b/tests/api/test_intake_interactions.py
@@ -39,6 +39,9 @@ from healthmes.nutrition.vision import VisionUnavailable
 from healthmes.storage import run_storage_maintenance
 from healthmes.store import RetentionPolicy, StorageObject, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("legacy_api_fixture_clock")
+
+
 JPEG = b"\xff\xd8\xff\xe0synthetic-coffee"
 
 

--- a/tests/api/test_nutrition_observations.py
+++ b/tests/api/test_nutrition_observations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
 from sqlalchemy import select
 
 from healthmes.nutrition.contracts import (
@@ -22,6 +23,9 @@ from healthmes.nutrition.schema import (
 from healthmes.nutrition.vision import VisionInvalidOutput, VisionUnavailable
 from healthmes.storage import run_storage_maintenance
 from healthmes.store import RetentionPolicy, StorageObject, WellnessEvent
+
+pytestmark = pytest.mark.usefixtures("legacy_api_fixture_clock")
+
 
 JPEG = b"\xff\xd8\xff\xe0synthetic-coffee"
 

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -25,6 +25,8 @@ from healthmes.store import (
     WellnessEvent,
 )
 
+pytestmark = pytest.mark.usefixtures("legacy_api_fixture_clock")
+
 
 def test_storage_settings_bootstraps_defaults_and_measures_files(
     client: TestClient, settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,12 @@ fixture points at in-memory sqlite and dummy endpoints, and disables both
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from freezegun import freeze_time
 
 from healthmes.app import create_app
 from healthmes.config import Settings
+
+LEGACY_FIXTURE_NOW = "2026-08-07T12:00:00Z"
 
 
 @pytest.fixture
@@ -72,3 +75,21 @@ def client(app: FastAPI):
         client=("127.0.0.1", 43123),
     ) as test_client:
         yield test_client
+
+
+@pytest.fixture
+def legacy_fixture_clock():
+    with freeze_time(LEGACY_FIXTURE_NOW, tick=True):
+        yield
+
+
+@pytest.fixture
+def legacy_api_fixture_clock(client):
+    """Freeze API test bodies only after the application is initialized.
+
+    FastAPI builds some route schemas lazily, and that construction must use
+    the real ``datetime`` classes rather than freezegun's replacements.
+    """
+    assert client.get("/__clock_prewarm__").status_code == 404
+    with freeze_time(LEGACY_FIXTURE_NOW, tick=True):
+        yield

--- a/tests/glue/test_bootstrap.py
+++ b/tests/glue/test_bootstrap.py
@@ -23,6 +23,7 @@ EXPECTED_SKILLS = (
     "healthmes-sleep",
     "healthmes-stress",
 )
+EXPECTED_PLUGINS = ("healthmes-routing",)
 
 pytestmark = pytest.mark.usefixtures("clean_env")
 
@@ -61,6 +62,7 @@ def test_full_run_builds_expected_tree(bootstrap, hermes_home, env_file, capsys)
 
     # 1. config.yaml rendered and parseable, with vendor-contract keys.
     config = yaml.safe_load((hermes_home / "config.yaml").read_text())
+    assert config["mcp_discovery_timeout"] == 20
     assert config["platforms"]["telegram"]["token"] == "123456:test-token"
     assert config["platforms"]["telegram"]["extra"]["allow_from"] == ["owner-user"]
     route = config["platforms"]["webhook"]["extra"]["routes"]["healthmes-alerts"]
@@ -93,7 +95,18 @@ def test_full_run_builds_expected_tree(bootstrap, hermes_home, env_file, capsys)
             REPO_ROOT / "skills" / skill / "SKILL.md"
         ).read_text()
 
-    # 3. Briefing snapshot script + base-url sidecar installed into the
+    # 3. Request-scoped routing plugins copied into Hermes discovery.
+    for plugin in EXPECTED_PLUGINS:
+        dest = hermes_home / "plugins" / plugin
+        assert dest.is_dir() and not dest.is_symlink()
+        assert (dest / "plugin.yaml").read_text() == (
+            REPO_ROOT / "plugins" / plugin / "plugin.yaml"
+        ).read_text()
+        assert (dest / "__init__.py").read_text() == (
+            REPO_ROOT / "plugins" / plugin / "__init__.py"
+        ).read_text()
+
+    # 4. Briefing snapshot script + base-url sidecar installed into the
     # scheduler's only allowed script location ($HERMES_HOME/scripts/).
     installed_script = hermes_home / "scripts" / "healthmes_briefing_snapshot.py"
     assert installed_script.is_file()
@@ -107,7 +120,7 @@ def test_full_run_builds_expected_tree(bootstrap, hermes_home, env_file, capsys)
     # and the sidecar carries no token key.
     assert "headers" not in servers["healthmes"]
 
-    # 4. Cron briefings registered in the vendor jobs.json envelope.
+    # 5. Cron briefings registered in the vendor jobs.json envelope.
     jobs_doc = yaml.safe_load((hermes_home / "cron" / "jobs.json").read_text())
     assert set(jobs_doc) >= {"jobs", "updated_at"}
     jobs = {job["name"]: job for job in jobs_doc["jobs"]}
@@ -353,6 +366,7 @@ def test_existing_config_is_merged_not_clobbered(bootstrap, hermes_home, env_fil
         yaml.safe_dump(
             {
                 "model": {"default": "user-chosen-model"},
+                "mcp_discovery_timeout": 1.5,
                 "platforms": {"telegram": {"token": "stale-token"}},
             }
         ),
@@ -363,6 +377,7 @@ def test_existing_config_is_merged_not_clobbered(bootstrap, hermes_home, env_fil
     config = yaml.safe_load((hermes_home / "config.yaml").read_text())
     # Unmanaged user keys survive; managed keys are overwritten.
     assert config["model"] == {"default": "user-chosen-model"}
+    assert config["mcp_discovery_timeout"] == 20
     assert config["platforms"]["telegram"]["token"] == "123456:test-token"
     assert "mcp_servers" in config
     # The pre-merge file was backed up exactly once.

--- a/tests/glue/test_healthmes_routing_plugin.py
+++ b/tests/glue/test_healthmes_routing_plugin.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+PLUGIN_PATH = (
+    Path(__file__).resolve().parents[2] / "plugins" / "healthmes-routing" / "__init__.py"
+)
+
+
+def _load_plugin():
+    spec = importlib.util.spec_from_file_location("healthmes_routing", PLUGIN_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_telegram_sleep_calendar_update_injects_authoritative_route() -> None:
+    plugin = _load_plugin()
+
+    result = plugin._inject_route(
+        user_message="7월 29일 Oura 수면 시간을 캘린더에 업데이트해줘.",
+        platform="telegram",
+    )
+
+    assert result is not None
+    context = result["context"]
+    assert "prepare_actual_sleep_calendar_update" in context
+    assert "Ignore any earlier conversational claim" in context
+    assert 'date_basis="night_start"' in context
+    assert "without calling a clarification tool" in context
+
+
+def test_explicit_sleep_times_route_to_oura_summary_date() -> None:
+    plugin = _load_plugin()
+
+    result = plugin._inject_route(
+        user_message="7/29: 01:23 → 09:01 이 수면 데이터를 캘린더에 업데이트해보자.",
+        platform="telegram",
+    )
+
+    assert result is not None
+    assert 'date_basis="oura_summary"' in result["context"]
+
+
+def test_refresh_request_forbids_reusing_a_previous_review_url() -> None:
+    plugin = _load_plugin()
+
+    result = plugin._inject_route(
+        user_message=(
+            "7/29 01:23 → 09:01 Oura 수면 기록으로 "
+            "캘린더 업데이트 링크 다시 만들어줘."
+        ),
+        platform="telegram",
+    )
+
+    assert result is not None
+    context = result["context"]
+    assert "Never answer from an earlier tool result" in context
+    assert "do not claim a preview or link was refreshed" in context
+
+
+def test_unrelated_turn_does_not_inject() -> None:
+    plugin = _load_plugin()
+
+    assert plugin._inject_route(
+        user_message="오늘 Oura 수면 어땠어?",
+        platform="telegram",
+    ) is None

--- a/tests/glue/test_hermes_config_template.py
+++ b/tests/glue/test_hermes_config_template.py
@@ -76,6 +76,10 @@ def test_telegram_platform_keys(config: dict) -> None:
     assert "*" not in telegram["extra"]["allow_from"]
 
 
+def test_mcp_discovery_wait_covers_local_server_startup(config: dict) -> None:
+    assert config["mcp_discovery_timeout"] == 20
+
+
 def test_home_channel_only_rendered_when_chat_id_set() -> None:
     full = render(dict(FULL_CONTEXT))
     home = full["platforms"]["telegram"]["home_channel"]

--- a/tests/glue/test_skills_docs.py
+++ b/tests/glue/test_skills_docs.py
@@ -74,3 +74,23 @@ def test_skill_dirs_all_checked() -> None:
         "healthmes-sleep",
         "healthmes-stress",
     ]
+
+
+@pytest.mark.parametrize("skill_name", ("healthmes-sleep", "healthmes-stress"))
+def test_current_health_skills_fail_closed_without_live_mcp(skill_name: str) -> None:
+    text = (REPO_ROOT / "skills" / skill_name / "SKILL.md").read_text(encoding="utf-8")
+    assert "fail closed: return `insufficient_data`" in text
+    assert "Do not search session memory or local files" in text
+    assert "reuse a past observation as current evidence" in text
+    assert "Do not\n  record a decision from substituted or stale evidence" in text
+
+
+@pytest.mark.parametrize(
+    ("doc_name", "minimum_commands"),
+    (("DEVELOPMENT.md", 2), ("EXTENDING.md", 1)),
+)
+def test_hermes_runtime_docs_install_mcp_extra(
+    doc_name: str, minimum_commands: int
+) -> None:
+    text = (REPO_ROOT / "docs" / doc_name).read_text(encoding="utf-8")
+    assert text.count("--extra messaging --extra mcp") >= minimum_commands

--- a/tests/mcp_server/conftest.py
+++ b/tests/mcp_server/conftest.py
@@ -68,6 +68,7 @@ class FakeOW:
         self.users: list[dict] = [{"id": USER_ID, "email": "user@example.com"}]
         self.health_scores: list[dict] = []
         self.sleep_summaries: list[dict] = []
+        self.sleep_sessions: list[dict] = []
         self.recovery_summaries: list[dict] = []
         self.workouts: list[dict] = []
         self.timeseries: list[dict] = []
@@ -180,6 +181,9 @@ class FakeOW:
             return httpx.Response(
                 200, json=_paginated(self._filter_by_date(self.recovery_summaries, params))
             )
+        if suffix == "events/sleep":
+            rows = self._filter_by_datetime(self.sleep_sessions, "start_time", params)
+            return httpx.Response(200, json=_paginated(rows))
         if suffix == "events/workouts":
             rows = self._filter_by_datetime(self.workouts, "start_time", params)
             return httpx.Response(200, json=_paginated(rows))

--- a/tests/mcp_server/test_activity_tools.py
+++ b/tests/mcp_server/test_activity_tools.py
@@ -2,6 +2,7 @@ import datetime as dt
 import json
 import uuid
 
+import pytest
 from fastmcp import Client, FastMCP
 from sqlalchemy import select
 
@@ -41,6 +42,8 @@ from healthmes.nutrition.intake_service import (
 )
 from healthmes.nutrition.repository import persist_daily_confirmation
 from healthmes.store import WellnessEvent
+
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
 
 
 def _seed_activity(store_factory, pinned_tz) -> None:

--- a/tests/mcp_server/test_server_app.py
+++ b/tests/mcp_server/test_server_app.py
@@ -54,6 +54,9 @@ ACTIVITY_TOOLS = {
     "get_overwork_context",
     "resolve_wellness_context",
 }
+SLEEP_CALENDAR_TOOLS = {
+    "prepare_actual_sleep_calendar_update",
+}
 EXPECTED_TOOLS = (
     TRANCHE_1_TOOLS
     | TRANCHE_2_TOOLS
@@ -61,6 +64,7 @@ EXPECTED_TOOLS = (
     | NUTRITION_TOOLS
     | CALENDAR_ADJUSTMENT_TOOLS
     | ACTIVITY_TOOLS
+    | SLEEP_CALENDAR_TOOLS
 )
 
 _INITIALIZE = {

--- a/tests/mcp_server/test_tools_caffeine.py
+++ b/tests/mcp_server/test_tools_caffeine.py
@@ -45,6 +45,8 @@ from healthmes.nutrition.repository import (
 from healthmes.storage import register_storage_object
 from healthmes.store import CalendarEventMirror, CalendarSource
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 def _seed_event(
     store_factory,

--- a/tests/mcp_server/test_tools_intake.py
+++ b/tests/mcp_server/test_tools_intake.py
@@ -20,6 +20,8 @@ from healthmes.nutrition.transcription import TranscriptionResult
 from healthmes.storage import register_storage_object
 from healthmes.trusted_session import issue_trusted_session_proof
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 def _trusted(tool_name, arguments):
     proof = issue_trusted_session_proof(

--- a/tests/mcp_server/test_tools_nutrition.py
+++ b/tests/mcp_server/test_tools_nutrition.py
@@ -30,6 +30,8 @@ from healthmes.storage import register_storage_object
 from healthmes.store import WellnessEvent
 from healthmes.trusted_session import issue_trusted_session_proof
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
 
 def _observation(observed_at: dt.datetime, media_path: str) -> NutritionObservation:
     return NutritionObservation(

--- a/tests/mcp_server/test_tools_store.py
+++ b/tests/mcp_server/test_tools_store.py
@@ -32,6 +32,7 @@ from healthmes.store import (
     TriggerEvent,
 )
 from healthmes.trusted_session import issue_trusted_session_proof
+from tests.calendars.conftest import FakeCalendarBackend
 
 TREE = {
     "type": "rule",
@@ -46,6 +47,52 @@ TREE = {
         },
     ],
 }
+
+
+class TestActualSleepCalendarUpdate:
+    async def test_prepares_preview_without_calendar_write(
+        self,
+        mcp_client,
+        mcp_env,
+        call_tool,
+        monkeypatch,
+    ):
+        backend = FakeCalendarBackend()
+        mcp_env.add_sleep_summary(
+            "2026-07-08",
+            start_time="2026-07-07T23:00:00+09:00",
+            end_time="2026-07-08T07:00:00+09:00",
+            duration_minutes=420,
+            time_in_bed_minutes=480,
+        )
+        monkeypatch.setattr(
+            server_module,
+            "write_source",
+            lambda settings: CalendarSource.GOOGLE,
+        )
+        monkeypatch.setattr(
+            server_module,
+            "_build_backend",
+            lambda settings, source: backend,
+        )
+
+        result = await call_tool(
+            mcp_client,
+            "prepare_actual_sleep_calendar_update",
+            {"date": "2026-07-08", "date_basis": "oura_summary"},
+        )
+
+        assert result["status"] == "preview_ready"
+        assert result["proposal_status"] == "pending"
+        assert result["calendar_write"] == "requires_local_browser_confirmation"
+        assert result["review_url"].startswith(
+            "http://127.0.0.1:8100/sleep?proposal="
+        )
+        assert result["preview"]["start_local"] == "2026-07-07T23:00:00+09:00"
+        assert result["preview"]["wake_time_local"] == "2026-07-08T07:00:00+09:00"
+        assert backend.created_drafts == []
+        assert backend.update_calls == []
+        assert backend.delete_calls == []
 OWNER_USER_ID = "owner-user"
 OWNER_CHAT_ID = "owner-chat"
 

--- a/tests/nutrition/test_vision.py
+++ b/tests/nutrition/test_vision.py
@@ -26,6 +26,9 @@ from healthmes.nutrition.vision import (
     create_vision_provider,
 )
 
+pytestmark = pytest.mark.usefixtures("legacy_fixture_clock")
+
+
 EXTRACTION = {
     "status": "insufficient_data",
     "confidence": "low",

--- a/tests/test_fixture_clock.py
+++ b/tests/test_fixture_clock.py
@@ -1,0 +1,7 @@
+from datetime import UTC, datetime, timedelta
+
+
+def test_legacy_fixture_clock_keeps_august_media_within_retention(legacy_fixture_clock):
+    captured_at = datetime(2026, 8, 5, 23, 30, tzinfo=UTC)
+
+    assert datetime.now(UTC) - captured_at < timedelta(days=7)


### PR DESCRIPTION
## Summary
- restores the `prepare_actual_sleep_calendar_update` preview-only MCP tool used by the weekly-plan cron path
- installs and verifies the HealthMes routing plugin during bootstrap so Hermes exposes the expected routing contract
- adds MCP, bootstrap, routing, and skill-contract regression coverage

Closes #170

## Validation
- `uv run pytest -q tests/mcp_server/test_server_app.py tests/mcp_server/test_tools_store.py tests/glue/test_bootstrap.py tests/glue/test_healthmes_routing_plugin.py tests/glue/test_hermes_config_template.py tests/glue/test_skills_docs.py` (101 passed)
- `uv run ruff check healthmes/mcp_server/server.py tests/mcp_server/test_server_app.py tests/mcp_server/test_tools_store.py scripts/bootstrap.py tests/glue/test_bootstrap.py tests/glue/test_healthmes_routing_plugin.py tests/glue/test_hermes_config_template.py tests/glue/test_skills_docs.py`

## Full suite note
`uv run pytest -q` currently has 95 unrelated failures in activity retention and nutrition-storage tests because their Aug 1/6 fixtures are older than the active 14-day retention window on Aug 16, plus storage-fixture setup failures. The restored MCP and bootstrap coverage passes.