### PR TITLE
hotfix: stabilize retention CI and consolidate dependency updates

### DIFF
--- a/.github/workflows/android-apps.yml
+++ b/.github/workflows/android-apps.yml
@@ -50,12 +50,6 @@ jobs:
           java-version: "21"
           cache: gradle
 
-      - name: Setup Android SDK tools
-        uses: android-actions/setup-android@v4
-
-      - name: Install Android SDK 37
-        run: sdkmanager "platforms;android-37"
-
       - name: Build all modules + run JVM unit tests
         run: >
           ./gradlew --no-daemon

--- a/.github/workflows/android-apps.yml
+++ b/.github/workflows/android-apps.yml
@@ -50,6 +50,9 @@ jobs:
           java-version: "21"
           cache: gradle
 
+      - name: Install Android SDK 37
+        run: sdkmanager "platforms;android-37"
+
       - name: Build all modules + run JVM unit tests
         run: >
           ./gradlew --no-daemon

--- a/.github/workflows/android-apps.yml
+++ b/.github/workflows/android-apps.yml
@@ -50,6 +50,9 @@ jobs:
           java-version: "21"
           cache: gradle
 
+      - name: Setup Android SDK tools
+        uses: android-actions/setup-android@v4
+
       - name: Install Android SDK 37
         run: sdkmanager "platforms;android-37"
 

--- a/apps/android-usage/README.md
+++ b/apps/android-usage/README.md
@@ -19,7 +19,7 @@ deliberately *duplicates* its pairing-prefs pattern instead of importing it.
 
 Toolchain for everything: Gradle 9.6.1, AGP 9.3.1 built-in Kotlin
 (+ `org.jetbrains.kotlin.plugin.compose` 2.4.10 for `:companion`), JDK 17+,
-`compileSdk = 37`. Point the build at an SDK with platform 37 via
+`compileSdk = 36`. Point the build at an SDK with platform 36 via
 `ANDROID_HOME` or `local.properties`.
 
 | Module | Type | minSdk | Key libraries | Build | JVM unit tests |

--- a/apps/android-usage/README.md
+++ b/apps/android-usage/README.md
@@ -17,17 +17,17 @@ deliberately *duplicates* its pairing-prefs pattern instead of importing it.
 
 ## Build matrix
 
-Toolchain for everything: Gradle 9.6.1 (wrapper), AGP 9.3.1, Kotlin 2.0.21
-(+ `org.jetbrains.kotlin.plugin.compose` 2.0.21 for `:companion`'s Glance
-code), JDK 17+, `compileSdk = 36`. Point the build at an SDK with platform 36
-via `ANDROID_HOME` or `local.properties`.
+Toolchain for everything: Gradle 9.6.1, AGP 9.3.1 built-in Kotlin
+(+ `org.jetbrains.kotlin.plugin.compose` 2.4.10 for `:companion`), JDK 17+,
+`compileSdk = 37`. Point the build at an SDK with platform 37 via
+`ANDROID_HOME` or `local.properties`.
 
 | Module | Type | minSdk | Key libraries | Build | JVM unit tests |
 |---|---|---|---|---|---|
 | `:app` | phone app | 26 | WorkManager 2.9.1, security-crypto | `:app:assembleDebug` | `:app:testDebugUnitTest` (hourly bucketing) |
 | `:shared` | library | 26 | security-crypto, org.json (platform) | `:shared:assembleDebug` | tested via `:companion` |
-| `:companion` | phone app | 26 | Compose BOM 2024.10.01 (material3), activity-compose 1.9.3, browser 1.10.0, Glance 1.1.1, WorkManager 2.9.1 | `:companion:assembleDebug` | `:companion:testDebugUnitTest` (glance/alerts/report/proposals contract parsers, state mapper, notification grammar + action plan, proposal-action logic, multipart upload bodies, curve geometry, focus-block selection) |
-| `:wear` | Wear OS app | 30 | tiles 1.4.1, protolayout 1.2.1, watchface-complications-data-source 1.2.1 | `:wear:assembleDebug` | — (logic lives in `:shared`, tested via `:companion`) |
+| `:companion` | phone app | 26 | Compose BOM 2026.06.01 (material3), activity-compose 1.9.3, browser 1.10.0, Glance 1.1.1, WorkManager 2.9.1 | `:companion:assembleDebug` | `:companion:testDebugUnitTest` (glance/alerts/report/proposals contract parsers, state mapper, notification grammar + action plan, proposal-action logic, multipart upload bodies, curve geometry, focus-block selection) |
+| `:wear` | Wear OS app | 30 | tiles 1.4.1, protolayout 1.4.2, watchface-complications-data-source 1.2.1 | `:wear:assembleDebug` | — (logic lives in `:shared`, tested via `:companion`) |
 
 ```bash
 cd apps/android-usage

--- a/apps/android-usage/app/build.gradle.kts
+++ b/apps/android-usage/app/build.gradle.kts
@@ -48,5 +48,5 @@ dependencies {
 
     // HourlyBucketer is pure Kotlin, testable on the JVM.
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.json:json:20240303")
+    testImplementation("org.json:json:20260719")
 }

--- a/apps/android-usage/app/build.gradle.kts
+++ b/apps/android-usage/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.healthmes.usagecollector"
-    compileSdk = 37
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.healthmes.usagecollector"
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.19.0")
+    implementation("androidx.core:core-ktx:1.18.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.12.0")
     // Periodic 30-min upload with constraints + exponential backoff.

--- a/apps/android-usage/app/build.gradle.kts
+++ b/apps/android-usage/app/build.gradle.kts
@@ -1,11 +1,10 @@
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {
     namespace = "com.healthmes.usagecollector"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.healthmes.usagecollector"
@@ -32,9 +31,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 }
 
 dependencies {

--- a/apps/android-usage/app/build.gradle.kts
+++ b/apps/android-usage/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-ktx:1.19.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.12.0")
     // Periodic 30-min upload with constraints + exponential backoff.

--- a/apps/android-usage/build.gradle.kts
+++ b/apps/android-usage/build.gradle.kts
@@ -3,7 +3,6 @@
 plugins {
     id("com.android.application") version "9.3.1" apply false
     id("com.android.library") version "9.3.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     // Required by :companion for Glance (@Composable) widget code; with
     // Kotlin 2.x the Compose compiler ships as this Kotlin subplugin and its
     // version must match the Kotlin version above.

--- a/apps/android-usage/build.gradle.kts
+++ b/apps/android-usage/build.gradle.kts
@@ -7,5 +7,5 @@ plugins {
     // Required by :companion for Glance (@Composable) widget code; with
     // Kotlin 2.x the Compose compiler ships as this Kotlin subplugin and its
     // version must match the Kotlin version above.
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
 }

--- a/apps/android-usage/companion/build.gradle.kts
+++ b/apps/android-usage/companion/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
 
     // Compose UI for the single-activity app. The BOM release pairs with the
     // Kotlin 2.0.x Compose compiler (runtime 1.7.x, material3 1.3.x).
-    val composeBom = platform("androidx.compose:compose-bom:2024.10.01")
+    val composeBom = platform("androidx.compose:compose-bom:2026.06.01")
     implementation(composeBom)
     implementation("androidx.activity:activity-compose:1.9.3")
     implementation("androidx.compose.ui:ui")

--- a/apps/android-usage/companion/build.gradle.kts
+++ b/apps/android-usage/companion/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 // before.
 android {
     namespace = "com.healthmes.companion"
-    compileSdk = 37
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.healthmes.companion"
@@ -52,7 +52,7 @@ android {
 dependencies {
     implementation(project(":shared"))
 
-    implementation("androidx.core:core-ktx:1.19.0")
+    implementation("androidx.core:core-ktx:1.18.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.12.0")
     // 15-minute periodic refresh + one-shot notification-action calls.

--- a/apps/android-usage/companion/build.gradle.kts
+++ b/apps/android-usage/companion/build.gradle.kts
@@ -57,7 +57,7 @@ android {
 dependencies {
     implementation(project(":shared"))
 
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-ktx:1.19.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.12.0")
     // 15-minute periodic refresh + one-shot notification-action calls.

--- a/apps/android-usage/companion/build.gradle.kts
+++ b/apps/android-usage/companion/build.gradle.kts
@@ -80,5 +80,5 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     // Unit tests exercise the shared org.json-based contract parsers on the
     // JVM; android.jar's org.json is a stub there, so bring the real one.
-    testImplementation("org.json:json:20240303")
+    testImplementation("org.json:json:20260719")
 }

--- a/apps/android-usage/companion/build.gradle.kts
+++ b/apps/android-usage/companion/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     // Compose UI + Glance widgets are @Composable code; with Kotlin 2.x the
     // Compose compiler is this Kotlin subplugin (version pinned in the root
     // build).
@@ -18,7 +17,7 @@ plugins {
 // before.
 android {
     namespace = "com.healthmes.companion"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.healthmes.companion"
@@ -45,10 +44,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
     }
@@ -66,13 +61,14 @@ dependencies {
     implementation("androidx.glance:glance-appwidget:1.1.1")
 
     // Compose UI for the single-activity app. The BOM release pairs with the
-    // Kotlin 2.0.x Compose compiler (runtime 1.7.x, material3 1.3.x).
+    // Kotlin 2.4.x Compose compiler.
     val composeBom = platform("androidx.compose:compose-bom:2026.06.01")
     implementation(composeBom)
     implementation("androidx.activity:activity-compose:1.9.3")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
 
     // Decision viewer: Custom Tabs first, in-app WebView fallback.
     implementation("androidx.browser:browser:1.10.0")

--- a/apps/android-usage/gradle.properties
+++ b/apps/android-usage/gradle.properties
@@ -7,9 +7,4 @@ android.useAndroidX=true
 # Namespaced R classes keep builds lean.
 android.nonTransitiveRClass=true
 
-# Keep the explicit Kotlin 2.0.21 plugins while the project migrates to
-# AGP 9's built-in Kotlin DSL in a dedicated change.
-android.builtInKotlin=false
-android.newDsl=false
-
 kotlin.code.style=official

--- a/apps/android-usage/shared/build.gradle.kts
+++ b/apps/android-usage/shared/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-ktx:1.19.0")
     // EncryptedSharedPreferences for base URL + token at rest (same artifact
     // and pattern as the :app collector's CollectorPrefs).
     implementation("androidx.security:security-crypto:1.1.0-alpha06")

--- a/apps/android-usage/shared/build.gradle.kts
+++ b/apps/android-usage/shared/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 // Shared glue for the issue #7 companion surfaces (:companion phone widget,
@@ -11,7 +10,7 @@ plugins {
 // module stays untouched.
 android {
     namespace = "com.healthmes.briefing"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         // Must stay <= every consumer's minSdk (:companion 26, :wear 30).
@@ -23,9 +22,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 }
 
 dependencies {

--- a/apps/android-usage/shared/build.gradle.kts
+++ b/apps/android-usage/shared/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 // module stays untouched.
 android {
     namespace = "com.healthmes.briefing"
-    compileSdk = 37
+    compileSdk = 36
 
     defaultConfig {
         // Must stay <= every consumer's minSdk (:companion 26, :wear 30).
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.19.0")
+    implementation("androidx.core:core-ktx:1.18.0")
     // EncryptedSharedPreferences for base URL + token at rest (same artifact
     // and pattern as the :app collector's CollectorPrefs).
     implementation("androidx.security:security-crypto:1.1.0-alpha06")

--- a/apps/android-usage/wear/build.gradle.kts
+++ b/apps/android-usage/wear/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 // deliverable (docs/design/WATCH-NOTIFICATIONS.ko.md).
 android {
     namespace = "com.healthmes.wear"
-    compileSdk = 37
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.healthmes.wear"
@@ -41,7 +41,7 @@ android {
 dependencies {
     implementation(project(":shared"))
 
-    implementation("androidx.core:core-ktx:1.19.0")
+    implementation("androidx.core:core-ktx:1.18.0")
     // Tiles and ProtoLayout stay on their compatible 1.4.x line.
     implementation("androidx.wear.tiles:tiles:1.4.1")
     implementation("androidx.wear.protolayout:protolayout:1.4.2")

--- a/apps/android-usage/wear/build.gradle.kts
+++ b/apps/android-usage/wear/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     // Tiles 1.4.x builds layouts with the protolayout 1.2.x builders.
     implementation("androidx.wear.tiles:tiles:1.4.1")
-    implementation("androidx.wear.protolayout:protolayout:1.2.1")
-    implementation("androidx.wear.protolayout:protolayout-material:1.2.1")
+    implementation("androidx.wear.protolayout:protolayout:1.4.2")
+    implementation("androidx.wear.protolayout:protolayout-material:1.4.2")
     // Watch-face complication data source (energy score).
     implementation("androidx.wear.watchface:watchface-complications-data-source:1.2.1")
     // CallbackToFutureAdapter for the ListenableFuture-based tile callbacks.

--- a/apps/android-usage/wear/build.gradle.kts
+++ b/apps/android-usage/wear/build.gradle.kts
@@ -45,7 +45,7 @@ android {
 dependencies {
     implementation(project(":shared"))
 
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-ktx:1.19.0")
     // Tiles 1.4.x builds layouts with the protolayout 1.2.x builders.
     implementation("androidx.wear.tiles:tiles:1.4.1")
     implementation("androidx.wear.protolayout:protolayout:1.4.2")

--- a/apps/android-usage/wear/build.gradle.kts
+++ b/apps/android-usage/wear/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
 }
 
 // Issue #7 Wear OS surface: a ProtoLayout tile (energy score + next block)
@@ -10,7 +9,7 @@ plugins {
 // deliverable (docs/design/WATCH-NOTIFICATIONS.ko.md).
 android {
     namespace = "com.healthmes.wear"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.healthmes.wear"
@@ -37,16 +36,13 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 }
 
 dependencies {
     implementation(project(":shared"))
 
     implementation("androidx.core:core-ktx:1.19.0")
-    // Tiles 1.4.x builds layouts with the protolayout 1.2.x builders.
+    // Tiles and ProtoLayout stay on their compatible 1.4.x line.
     implementation("androidx.wear.tiles:tiles:1.4.1")
     implementation("androidx.wear.protolayout:protolayout:1.4.2")
     implementation("androidx.wear.protolayout:protolayout-material:1.4.2")

--- a/apps/windows-companion/src/HealthMes.Windows.Common/HealthMes.Windows.Common.csproj
+++ b/apps/windows-companion/src/HealthMes.Windows.Common/HealthMes.Windows.Common.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <!-- DPAPI (ProtectedData) — Microsoft-published compatibility package. -->
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/healthmes/activity/activitywatch.py
+++ b/healthmes/activity/activitywatch.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.aggregation import (
     rebuild_affected_days,
     summary_raw_provenance_complete,
@@ -1036,7 +1037,7 @@ def prepare_activitywatch_import(
     The reservation is intentionally committed before network I/O. Callers
     must treat this adapter operation as its own transaction boundary.
     """
-    current = (now or datetime.now(UTC)).astimezone(UTC)
+    current = (now or clock.utc_now()).astimezone(UTC)
     if request.end_at is not None and request.end_at > current + MAX_FUTURE_SKEW:
         raise ActivityWatchRequestError(
             "ActivityWatch import end cannot be in the future"

--- a/healthmes/activity/aggregation.py
+++ b/healthmes/activity/aggregation.py
@@ -13,6 +13,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.locking import lock_activity_write_plane
 from healthmes.activity.repository import (
     ACTIVITY_DAILY_CLASS,
@@ -894,7 +895,7 @@ def personal_baseline_delta(
 ) -> dict[str, Any]:
     if not 1 <= lookback_days <= 90:
         raise ValueError("lookback_days must be between 1 and 90")
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     name = timezone_name(timezone)
     start_day = day - timedelta(days=lookback_days)
     rows = list(
@@ -958,7 +959,7 @@ def rebuild_day_summaries(
     force_rebuild: bool = False,
     now: datetime | None = None,
 ) -> WellnessEvent | None:
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     lock_activity_write_plane(session)
     name = timezone_name(timezone)
     start, end = local_day_bounds(day, timezone)
@@ -1268,7 +1269,7 @@ def rebuild_affected_days(
     force_rebuild: bool = False,
     now: datetime | None = None,
 ) -> list[WellnessEvent]:
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     primary = set(days)
     rebuilt: list[WellnessEvent] = []
     for day in sorted(primary):
@@ -1427,7 +1428,7 @@ def migrate_activity_summary_derivations(
     now: datetime | None = None,
 ) -> ActivitySummaryMigrationReport:
     """Rebuild compatible legacy summaries and leave unsafe ones unreadable."""
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     lock_activity_write_plane(session)
     migrated = 0
     incompatible = 0
@@ -1467,7 +1468,7 @@ def refresh_existing_day_baseline(
     timezone: str | tzinfo,
     now: datetime | None = None,
 ) -> WellnessEvent | None:
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     lock_activity_write_plane(session)
     event = _daily_summary_event(session, day=day, timezone=timezone)
     if event is None or not summary_has_current_derivation(event):

--- a/healthmes/activity/android.py
+++ b/healthmes/activity/android.py
@@ -9,6 +9,7 @@ from typing import Protocol
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.contracts import (
     ActivityBatchIn,
     ActivityBatchOut,
@@ -109,7 +110,7 @@ def android_batch(
         platform=ActivityPlatform.ANDROID,
         capability=ActivityCapability.AGGREGATE,
         timezone=timezone,
-        collected_at=collected_at or datetime.now(UTC),
+        collected_at=collected_at or clock.utc_now(),
         collection_revision=collection_revision,
         records=[
             AppHourRecord(
@@ -191,7 +192,7 @@ def backfill_android_canonical_events(
     timezone: str,
     now: datetime | None = None,
 ) -> ActivityIngestResult | None:
-    current = (now or datetime.now(UTC)).astimezone(UTC)
+    current = (now or clock.utc_now()).astimezone(UTC)
     with activity_write_lock():
         lock_activity_write_plane(session)
         raw_policy = ensure_activity_policies(session)[ACTIVITY_RAW_CLASS]

--- a/healthmes/activity/api.py
+++ b/healthmes/activity/api.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Path, Query, Request
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.activitywatch import (
     ActivityWatchError,
     ActivityWatchRequestError,
@@ -389,7 +390,7 @@ def pause_collection(
     body: ActivityPauseRequest,
     session: SessionDep,
 ) -> ActivityCollectionOut:
-    if body.until <= datetime.now(UTC):
+    if body.until <= clock.utc_now():
         raise APIError(422, "invalid_pause", "pause deadline must be in the future")
     with activity_write_lock():
         payload = update_collection_config(
@@ -449,7 +450,7 @@ def post_collection_status(
                 "and collection_generation",
             )
     observed_at = body.status_observed_at
-    current = datetime.now(UTC)
+    current = clock.utc_now()
     if observed_at is not None and observed_at > current + MAX_FUTURE_SKEW:
         raise APIError(
             409,
@@ -564,7 +565,7 @@ def post_ios_report(
     session: SessionDep,
 ) -> ActivityBatchOut:
     with activity_write_lock():
-        uploaded_at = datetime.now(UTC)
+        uploaded_at = clock.utc_now()
         if body.collected_at > uploaded_at + MAX_FUTURE_SKEW:
             raise APIError(
                 409,
@@ -933,7 +934,7 @@ def get_focus_context(
         raise APIError(422, "invalid_time_range", "start must be before end")
     if end - start > timedelta(days=1):
         raise APIError(422, "invalid_time_range", "focus window cannot exceed 24 hours")
-    if end.astimezone(UTC) > datetime.now(UTC) + timedelta(minutes=1):
+    if end.astimezone(UTC) > clock.utc_now() + timedelta(minutes=1):
         raise APIError(422, "invalid_time_range", "future activity is unknown")
     return focus_context(
         session,

--- a/healthmes/activity/context.py
+++ b/healthmes/activity/context.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.aggregation import (
     LEGACY_SUMMARY_REASON,
     get_daily_summary,
@@ -673,4 +674,4 @@ def recovery_activity_context(
 
 def default_focus_window(day: date, timezone: str | tzinfo) -> tuple[datetime, datetime]:
     start, end = local_day_bounds(day, timezone)
-    return start, min(end, datetime.now(UTC) + timedelta(seconds=1))
+    return start, min(end, clock.utc_now() + timedelta(seconds=1))

--- a/healthmes/activity/contracts.py
+++ b/healthmes/activity/contracts.py
@@ -17,6 +17,7 @@ from pydantic import (
     model_validator,
 )
 
+from healthmes import clock
 from healthmes.timezones import parse_timezone
 
 RESERVED_ACTIVITY_PROVIDER_NAMES = frozenset(
@@ -154,7 +155,7 @@ class ActivityBatchIn(BaseModel):
     platform: ActivityPlatform
     capability: ActivityCapability
     timezone: str = Field(min_length=1, max_length=64)
-    collected_at: AwareDatetime = Field(default_factory=lambda: datetime.now(UTC))
+    collected_at: AwareDatetime = Field(default_factory=lambda: clock.utc_now())
     collection_revision: int | None = Field(default=None, ge=0)
     records: list[ActivityRecord] = Field(min_length=1, max_length=5000)
 
@@ -329,7 +330,7 @@ class IOSCapabilityReport(BaseModel):
     capability: ActivityCapability
     permission_status: ActivityPermissionStatus
     reason: str | None = Field(default=None, max_length=255)
-    collected_at: AwareDatetime = Field(default_factory=lambda: datetime.now(UTC))
+    collected_at: AwareDatetime = Field(default_factory=lambda: clock.utc_now())
     collection_revision: int | None = Field(default=None, ge=0)
     collection_generation: int | None = Field(
         default=None,

--- a/healthmes/activity/maintenance.py
+++ b/healthmes/activity/maintenance.py
@@ -12,6 +12,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.aggregation import (
     BASELINE_DAYS,
     refresh_existing_day_baseline,
@@ -285,7 +286,7 @@ def run_activity_maintenance(
 ) -> ActivityMaintenanceReport:
     with activity_write_lock():
         lock_activity_write_plane(session)
-        current = as_utc(now or datetime.now(UTC))
+        current = as_utc(now or clock.utc_now())
         policies = ensure_activity_policies(session)
         expired = list(
             session.scalars(
@@ -404,7 +405,7 @@ def delete_activity_data(
 ) -> ActivityDeleteReport:
     with activity_write_lock():
         lock_activity_write_plane(session)
-        current = as_utc(now or datetime.now(UTC))
+        current = as_utc(now or clock.utc_now())
         effective_end = min(as_utc(end), current) if end is not None else current
         selection_end = (
             None

--- a/healthmes/activity/mcp.py
+++ b/healthmes/activity/mcp.py
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.context import (
     activity_summary_context,
     focus_context,
@@ -82,7 +83,7 @@ def register_activity_tools(
             raise ToolError("start must be before end")
         if end_at - start_at > timedelta(days=1):
             raise ToolError("focus window cannot exceed 24 hours")
-        if end_at > datetime.now(UTC) + timedelta(minutes=1):
+        if end_at > clock.utc_now() + timedelta(minutes=1):
             raise ToolError("future activity is unknown")
         with store_session_factory() as session:
             return focus_context(

--- a/healthmes/activity/privacy.py
+++ b/healthmes/activity/privacy.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from healthmes import clock
 from healthmes.activity.contracts import (
     ActivityPermissionStatus,
     ActivityRecord,
@@ -88,7 +89,7 @@ def collection_gate(
     *,
     now: datetime | None = None,
 ) -> CollectionGate:
-    current = _as_utc(now) or datetime.now(UTC)
+    current = _as_utc(now) or clock.utc_now()
     if not bool(state.get("enabled", True)):
         return CollectionGate(False, "collection_disabled")
     permission = str(state.get("permission_status", "unknown"))

--- a/healthmes/activity/repository.py
+++ b/healthmes/activity/repository.py
@@ -14,6 +14,7 @@ from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.contracts import (
     ActivityBatchIn,
     ActivityCapability,
@@ -244,7 +245,7 @@ def event_is_expired(
     now: datetime | None = None,
 ) -> bool:
     expires_at = parse_optional_datetime(event.expires_at)
-    return expires_at is not None and expires_at <= as_utc(now or datetime.now(UTC))
+    return expires_at is not None and expires_at <= as_utc(now or clock.utc_now())
 
 
 def fixed_offset_summary_scopes_by_change(
@@ -254,7 +255,7 @@ def fixed_offset_summary_scopes_by_change(
     now: datetime | None = None,
 ) -> dict[str, set[ActivityLocalScope]]:
     """Map raw changes to materialized fixed-offset summaries they can affect."""
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     normalized: list[tuple[ActivityChangeWindow, datetime, datetime, Any]] = []
     scopes_by_key: dict[str, set[ActivityLocalScope]] = {}
     for change in changes:
@@ -332,7 +333,7 @@ def legacy_app_usage_cutoff(
         return None
     else:
         retention_days = policy.retention_days
-    return as_utc(now or datetime.now(UTC)) - timedelta(days=retention_days)
+    return as_utc(now or clock.utc_now()) - timedelta(days=retention_days)
 
 
 def activity_source_identity_digest(
@@ -1065,7 +1066,7 @@ def _persist_control_payload(
     now: datetime | None = None,
 ) -> WellnessEvent:
     lock_activity_control_device(session, device_id)
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     event = session.scalar(
         select(WellnessEvent)
         .where(
@@ -1410,7 +1411,7 @@ def update_collection_status(
     with activity_write_lock():
         lock_activity_write_plane(session)
         lock_activity_control_device(session, device_id)
-        current = as_utc(now or datetime.now(UTC))
+        current = as_utc(now or clock.utc_now())
         for attempt in range(2):
             payload = {
                 "device_id": device_id,
@@ -1534,7 +1535,7 @@ def create_deletion_tombstone(
     blocked_identity_digests: Iterable[str] = (),
     now: datetime | None = None,
 ) -> WellnessEvent:
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     normalized_start = as_utc(start) if start is not None else None
     normalized_end = min(as_utc(end), current)
     if normalized_start is not None and normalized_start >= normalized_end:
@@ -1895,7 +1896,7 @@ def serialize_collection_state(
     *,
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    current = as_utc(now or datetime.now(UTC))
+    current = as_utc(now or clock.utc_now())
     gate = collection_gate(payload, now=current)
     queue_oldest = parse_optional_datetime(payload.get("queue_oldest_at"))
     queue_age = (
@@ -1956,7 +1957,7 @@ def upsert_summary_event(
         )
         .with_for_update()
     )
-    current = datetime.now(UTC)
+    current = clock.utc_now()
     if event is None:
         event = WellnessEvent(
             event_type=event_type,

--- a/healthmes/activity/resolver.py
+++ b/healthmes/activity/resolver.py
@@ -11,6 +11,7 @@ from typing import Any
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.aggregation import local_day_bounds, timezone_name
 from healthmes.activity.context import (
     MIN_CONTEXT_COVERAGE,
@@ -64,7 +65,7 @@ def _parse_day(
         return date.fromisoformat(value)
     if start is not None:
         return start.astimezone(_zone(timezone)).date()
-    return (now or datetime.now(UTC)).astimezone(_zone(timezone)).date()
+    return (now or clock.utc_now()).astimezone(_zone(timezone)).date()
 
 
 def _zone(value: str | tzinfo) -> tzinfo:
@@ -1162,7 +1163,7 @@ async def resolve_wellness_context(
     timezone_value: str | tzinfo = request.timezone or default_timezone
     timezone = _timezone_name(timezone_value)
     zone = _zone(timezone_value)
-    current = (now or datetime.now(UTC)).astimezone(UTC)
+    current = (now or clock.utc_now()).astimezone(UTC)
     day = _parse_day(
         request.date,
         zone,

--- a/healthmes/activity/service.py
+++ b/healthmes/activity/service.py
@@ -8,6 +8,7 @@ from datetime import UTC, date, datetime, timedelta
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.aggregation import (
     rebuild_affected_days,
     summary_raw_provenance_complete,
@@ -311,7 +312,7 @@ def ingest_activity_batch(
     prevalidated_summary_scopes: set[ActivityLocalScope] | None = None,
     update_permission_status: bool = False,
 ) -> ActivityIngestResult:
-    current = (now or datetime.now(UTC)).astimezone(UTC)
+    current = (now or clock.utc_now()).astimezone(UTC)
     with activity_write_lock():
         lock_activity_write_plane(session)
         _reject_future_data(batch, now=current)

--- a/healthmes/api/app_usage.py
+++ b/healthmes/api/app_usage.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from healthmes import clock
 from healthmes.activity.aggregation import (
     rebuild_affected_days,
     summary_raw_provenance_complete,
@@ -895,7 +896,7 @@ def ingest_batch(
                         session=session,
                         state=state,
                         timezone=timezone,
-                        now=datetime.now(UTC),
+                        now=clock.utc_now(),
                     )
             except ActivityConflictError as exc:
                 raise APIError(

--- a/healthmes/api/common.py
+++ b/healthmes/api/common.py
@@ -13,6 +13,8 @@ from typing import Annotated
 
 from pydantic import AfterValidator
 
+from healthmes import clock
+
 __all__ = ["ensure_utc", "utc_now", "UTCDateTime"]
 
 
@@ -24,8 +26,8 @@ def ensure_utc(value: datetime) -> datetime:
 
 
 def utc_now() -> datetime:
-    """Current aware UTC time (single seam for tests via freezegun)."""
-    return datetime.now(UTC)
+    """Current aware UTC time."""
+    return clock.utc_now()
 
 
 # Pydantic field type: any incoming datetime is normalised to aware UTC.

--- a/healthmes/api/intake_interactions.py
+++ b/healthmes/api/intake_interactions.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, timedelta
 from typing import Annotated, Self
 
 from fastapi import APIRouter, Request, status
 from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
+from healthmes import clock
 from healthmes.api.common import utc_now
 from healthmes.api.errors import APIError, not_found
 from healthmes.config import Settings
@@ -169,7 +170,7 @@ class CreateInteractionInput(BaseModel):
             ) from exc
         if self.observed_at.utcoffset() != self.observed_at.astimezone(timezone).utcoffset():
             raise ValueError("observed_at offset conflicts with timezone")
-        if self.observed_at.astimezone(UTC) > datetime.now(UTC) + MAX_CAPTURE_CLOCK_SKEW:
+        if self.observed_at.astimezone(UTC) > clock.utc_now() + MAX_CAPTURE_CLOCK_SKEW:
             raise ValueError("observed_at cannot be more than 5 minutes in the future")
         return self
 
@@ -205,7 +206,7 @@ class AnalyzeInteractionInput(BaseModel):
             != self.observed_at.astimezone(timezone).utcoffset()
         ):
             raise ValueError("observed_at offset conflicts with timezone")
-        if self.observed_at.astimezone(UTC) > datetime.now(UTC) + MAX_CAPTURE_CLOCK_SKEW:
+        if self.observed_at.astimezone(UTC) > clock.utc_now() + MAX_CAPTURE_CLOCK_SKEW:
             raise ValueError("observed_at cannot be more than 5 minutes in the future")
         if self.modality is CaptureModality.TEXT:
             if not self.source_text or not self.source_text.strip():

--- a/healthmes/api/nutrition_observations.py
+++ b/healthmes/api/nutrition_observations.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date, timedelta
 from hashlib import sha256
 from typing import Annotated, Literal, Self
 
 from fastapi import APIRouter, Request, status
 from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
+from healthmes import clock
 from healthmes.api.common import utc_now
 from healthmes.api.errors import APIError, not_found
 from healthmes.api.media import resolve_media_file
@@ -93,7 +94,7 @@ class AnalyzeNutritionPhoto(BaseModel):
         expected_offset = self.captured_at.astimezone(timezone).utcoffset()
         if self.captured_at.utcoffset() != expected_offset:
             raise ValueError("captured_at offset conflicts with timezone")
-        if self.captured_at.astimezone(UTC) > datetime.now(UTC) + MAX_CAPTURE_CLOCK_SKEW:
+        if self.captured_at.astimezone(UTC) > clock.utc_now() + MAX_CAPTURE_CLOCK_SKEW:
             raise ValueError("captured_at cannot be more than 5 minutes in the future")
         required = {"captured_at", "timezone", "location"}
         if not required.issubset(self.metadata_provenance):

--- a/healthmes/api/storage.py
+++ b/healthmes/api/storage.py
@@ -15,6 +15,7 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from healthmes import clock
 from healthmes.activity.contracts import is_reserved_activity_provider
 from healthmes.activity.locking import activity_write_lock
 from healthmes.api.decision_html import shell_context, template_environment
@@ -199,7 +200,7 @@ def create_wellness_event(
             "unsupported_wellness_data_class",
             "external wellness events must use the normalized data class",
         )
-    if body.observed_at.astimezone(UTC) > datetime.now(UTC) + timedelta(
+    if body.observed_at.astimezone(UTC) > clock.utc_now() + timedelta(
         minutes=5
     ):
         raise APIError(
@@ -223,7 +224,7 @@ def create_wellness_event(
                 if event.expires_at.tzinfo is None
                 else event.expires_at.astimezone(UTC)
             )
-            <= datetime.now(UTC)
+            <= clock.utc_now()
         ):
             raise APIError(
                 409,

--- a/healthmes/clock.py
+++ b/healthmes/clock.py
@@ -1,0 +1,8 @@
+"""Process clock seam for deterministic runtime and test time."""
+
+from datetime import UTC, datetime
+
+
+def utc_now() -> datetime:
+    """Return the current aware UTC time."""
+    return datetime.now(UTC)

--- a/healthmes/nutrition/intake_query.py
+++ b/healthmes/nutrition/intake_query.py
@@ -11,6 +11,7 @@ from pydantic import TypeAdapter
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.nutrition.intake_contracts import (
     CaptureModality,
     IntakeDecision,
@@ -160,7 +161,7 @@ def _latest_request_candidate(
             WellnessEvent.event_type == DECISION_REQUEST_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
             WellnessEvent.payload["interaction_id"].as_string()
             == str(interaction_id),
@@ -259,7 +260,7 @@ def search_intake_history(
             WellnessEvent.event_type == INTERACTION_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
         )
         .order_by(WellnessEvent.observed_at.desc(), WellnessEvent.created_at.desc())
@@ -289,7 +290,7 @@ def search_intake_history(
             WellnessEvent.event_type == OUTCOME_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())
@@ -321,7 +322,7 @@ def search_intake_history(
             WellnessEvent.event_type == DECISION_REQUEST_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())
@@ -383,7 +384,7 @@ def _confirmed_history(
             WellnessEvent.event_type == OUTCOME_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())

--- a/healthmes/nutrition/intake_service.py
+++ b/healthmes/nutrition/intake_service.py
@@ -16,6 +16,7 @@ from sqlalchemy import event, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.config import Settings
 from healthmes.nutrition.contracts import (
     ConfirmationStatus,
@@ -157,7 +158,7 @@ def _claim_process_local_persistence(
     reservation_token: str,
 ) -> None:
     key = (id(session.get_bind()), interaction.interaction_id)
-    now = datetime.now(UTC)
+    now = clock.utc_now()
     with _STATIC_ANALYSIS_RESERVATIONS_LOCK:
         reservation = _STATIC_ANALYSIS_RESERVATIONS.get(key)
         if (
@@ -318,7 +319,7 @@ def _reject_expired_idempotent(
 ) -> None:
     if (
         event.expires_at is not None
-        and _stored_as_utc(event.expires_at) <= datetime.now(UTC)
+        and _stored_as_utc(event.expires_at) <= clock.utc_now()
     ):
         raise IntakeOperationConflict(
             f"expired {operation_name} cannot be retried"
@@ -468,7 +469,7 @@ def _reserve_interaction_analysis(
     lease_seconds: float,
 ) -> str:
     reservation_token = uuid.uuid4().hex
-    now = datetime.now(UTC)
+    now = clock.utc_now()
     lease_expires_at = now + timedelta(seconds=lease_seconds)
     bind = session.get_bind()
     if _uses_process_local_reservations(session):
@@ -1134,7 +1135,7 @@ def create_interaction(
         )
     observed_at = _as_utc(interaction.observed_at)
     recorded_at = _as_utc(interaction.recorded_at)
-    if observed_at > datetime.now(UTC) + MAX_CAPTURE_CLOCK_SKEW:
+    if observed_at > clock.utc_now() + MAX_CAPTURE_CLOCK_SKEW:
         raise IntakeInteractionError(
             "observed_at cannot be more than 5 minutes in the future"
         )
@@ -1228,7 +1229,7 @@ def create_interaction(
     structured_expiry = _expiry(policy, observed_at)
     if (
         structured_expiry is not None
-        and structured_expiry <= datetime.now(UTC)
+        and structured_expiry <= clock.utc_now()
     ):
         raise IntakeInteractionError(
             "observed_at falls outside the structured retention window"
@@ -1339,7 +1340,7 @@ def get_interaction(
         event is None
         or (
             event.expires_at is not None
-            and _stored_as_utc(event.expires_at) <= datetime.now(UTC)
+            and _stored_as_utc(event.expires_at) <= clock.utc_now()
         )
     ):
         return None
@@ -1353,7 +1354,7 @@ def get_interaction(
         raw is not None
         and (
             raw.expires_at is None
-            or _stored_as_utc(raw.expires_at) > datetime.now(UTC)
+            or _stored_as_utc(raw.expires_at) > clock.utc_now()
         )
     )
     source_text = interaction.source_text
@@ -1411,7 +1412,7 @@ def get_interaction(
             raw is not None
             or (
                 raw_expiry is not None
-                and raw_expiry <= datetime.now(UTC)
+                and raw_expiry <= clock.utc_now()
             )
         ):
             source_text = None
@@ -1651,7 +1652,7 @@ def latest_outcome(
             WellnessEvent.event_type == OUTCOME_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
             WellnessEvent.payload["interaction_id"].as_string()
             == str(interaction_id),
@@ -1671,7 +1672,7 @@ def latest_outcome(
                 raw is not None
                 and (
                     raw.expires_at is None
-                    or _stored_as_utc(raw.expires_at) > datetime.now(UTC)
+                    or _stored_as_utc(raw.expires_at) > clock.utc_now()
                 )
                 and isinstance(raw.payload.get("note"), str)
             ):
@@ -1695,7 +1696,7 @@ def list_interactions(
             WellnessEvent.event_type == INTERACTION_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
         )
         .order_by(WellnessEvent.observed_at.desc(), WellnessEvent.created_at.desc())
@@ -1837,7 +1838,7 @@ def get_decision_request(
         event is None
         or (
             event.expires_at is not None
-            and _stored_as_utc(event.expires_at) <= datetime.now(UTC)
+            and _stored_as_utc(event.expires_at) <= clock.utc_now()
         )
     ):
         return None
@@ -2016,7 +2017,7 @@ def latest_decision(
             WellnessEvent.event_type == DECISION_EVENT,
             (
                 WellnessEvent.expires_at.is_(None)
-                | (WellnessEvent.expires_at > datetime.now(UTC))
+                | (WellnessEvent.expires_at > clock.utc_now())
             ),
             WellnessEvent.payload["interaction_id"].as_string()
             == str(interaction_id),

--- a/healthmes/nutrition/repository.py
+++ b/healthmes/nutrition/repository.py
@@ -12,6 +12,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.config import Settings
 from healthmes.nutrition.contracts import (
     CaffeineConfirmation,
@@ -94,7 +95,7 @@ def _expiry(policy: RetentionPolicy, observed_at: datetime) -> datetime | None:
 
 
 def storage_object_for_media(session: Session, media_path: str) -> StorageObject | None:
-    now = datetime.now(UTC)
+    now = clock.utc_now()
     return session.scalar(
         select(StorageObject).where(
             StorageObject.relative_path == media_path,
@@ -121,7 +122,7 @@ def observation_for_media(
             WellnessEvent.raw_object_id == storage_object_id,
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc())
@@ -202,7 +203,7 @@ def persist_observation(
         raise NutritionRepositoryError("nutrition observations require an image object")
 
     observed_at = _as_utc(observation.capture.captured_at)
-    if observed_at > datetime.now(UTC) + MAX_CAPTURE_CLOCK_SKEW:
+    if observed_at > clock.utc_now() + MAX_CAPTURE_CLOCK_SKEW:
         raise NutritionRepositoryError(
             "captured_at cannot be more than 5 minutes in the future"
         )
@@ -210,7 +211,7 @@ def persist_observation(
     structured_expiry = _expiry(policy, observed_at)
     if (
         structured_expiry is not None
-        and structured_expiry <= datetime.now(UTC)
+        and structured_expiry <= clock.utc_now()
     ):
         raise NutritionRepositoryError(
             "captured_at falls outside the observation retention window"
@@ -310,7 +311,7 @@ def get_observation(
             WellnessEvent.source_record_id == str(observation_id),
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
     )
@@ -323,7 +324,7 @@ def get_observation(
             WellnessEvent.source_record_id == str(observation_id),
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
     )
@@ -346,7 +347,7 @@ def list_observations(
             WellnessEvent.source_provider == SOURCE_PROVIDER,
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
         .order_by(WellnessEvent.observed_at.desc(), WellnessEvent.created_at.desc())
@@ -625,7 +626,7 @@ def persist_daily_confirmation(
                 WellnessEvent.observed_at < end,
                 or_(
                     WellnessEvent.expires_at.is_(None),
-                    WellnessEvent.expires_at > datetime.now(UTC),
+                    WellnessEvent.expires_at > clock.utc_now(),
                 ),
             )
         )
@@ -703,7 +704,7 @@ def latest_intake_outcome_states(
             WellnessEvent.source_provider == INTAKE_OUTCOME_PROVIDER,
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())
@@ -728,7 +729,7 @@ def intake_outcome_states_for_day(
             WellnessEvent.source_provider == INTAKE_OUTCOME_PROVIDER,
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())
@@ -767,7 +768,7 @@ def latest_caffeine_confirmations(
             WellnessEvent.source_provider == "user-confirmation",
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())
@@ -795,7 +796,7 @@ def latest_nutrition_reviews(
             WellnessEvent.source_provider == "user-nutrition-review",
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())
@@ -821,7 +822,7 @@ def latest_daily_confirmation(
             WellnessEvent.source_provider == "user-confirmation",
             or_(
                 WellnessEvent.expires_at.is_(None),
-                WellnessEvent.expires_at > datetime.now(UTC),
+                WellnessEvent.expires_at > clock.utc_now(),
             ),
         )
         .order_by(WellnessEvent.recorded_at.desc(), WellnessEvent.created_at.desc())

--- a/healthmes/storage/service.py
+++ b/healthmes/storage/service.py
@@ -14,6 +14,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
+from healthmes import clock
 from healthmes.activity.locking import (
     activity_write_lock,
     lock_activity_write_plane,
@@ -80,7 +81,7 @@ def build_storage_maintenance_job(settings: Settings):
 
 
 def _now() -> datetime:
-    return datetime.now(UTC)
+    return clock.utc_now()
 
 
 def ensure_default_policies(session: Session) -> list[RetentionPolicy]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     # age encryption for the Phase-3 local-first backup module
     "pyrage",
     # S3-compatible remote vault replication (RemoteVaultProvider, PLAN §9)
-    "boto3>=1.43.58",
+    "boto3>=1.43.67",
     # Multipart parsing for the capture upload (POST /v1/media, issue #10) —
     # previously only a transitive dep of fastmcp; FastAPI needs it directly.
     "python-multipart>=0.0.32",

--- a/tests/activity/test_aggregation_retention.py
+++ b/tests/activity/test_aggregation_retention.py
@@ -58,6 +58,8 @@ from healthmes.storage import (
 )
 from healthmes.store import AppUsageSample, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def _interval_batch(
     records: list[AppIntervalRecord],
@@ -1315,8 +1317,9 @@ def test_natural_raw_expiry_keeps_longer_lived_hourly_and_daily_summaries(sessio
 
 def test_shortening_activity_raw_retention_deletes_expired_legacy_rows_immediately(
     session,
+    fixture_clock,
 ) -> None:
-    now = datetime.now(UTC)
+    now = fixture_clock()
     session.add(
         AppUsageSample(
             device_id="legacy-expired-on-policy-change",
@@ -1344,8 +1347,9 @@ def test_shortening_activity_raw_retention_deletes_expired_legacy_rows_immediate
 
 def test_switching_activity_raw_retention_to_forever_does_not_resurrect_legacy_rows(
     session,
+    fixture_clock,
 ) -> None:
-    now = datetime.now(UTC)
+    now = fixture_clock()
     update_retention_policy(session, "activity_raw", "1d")
     session.add_all(
         [

--- a/tests/activity/test_ingest_privacy.py
+++ b/tests/activity/test_ingest_privacy.py
@@ -42,6 +42,8 @@ from healthmes.activity.service import (
 )
 from healthmes.store import RetentionPolicy, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def _hour_batch(
     *,

--- a/tests/activity/test_resolver.py
+++ b/tests/activity/test_resolver.py
@@ -50,6 +50,8 @@ from healthmes.nutrition.intake_service import (
 from healthmes.nutrition.repository import persist_daily_confirmation
 from healthmes.store import CalendarEventMirror, CalendarSource, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def _seed_activity(session) -> None:
     ingest_activity_batch(

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -17,6 +17,8 @@ from healthmes.activity.repository import (
 from healthmes.activity.service import ingest_activity_batch
 from healthmes.store import WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def _hour_record(
     *,

--- a/tests/api/test_app_usage.py
+++ b/tests/api/test_app_usage.py
@@ -16,6 +16,8 @@ from healthmes.activity.repository import (
 from healthmes.storage import update_retention_policy
 from healthmes.store import AppUsageSample, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def _batch(samples):
     return {
@@ -613,8 +615,9 @@ def test_incomplete_empty_source_set_preserves_completed_hour_and_new_upload(
 def test_expired_incomplete_heartbeat_does_not_block_current_snapshot(
     client,
     session,
+    fixture_clock,
 ):
-    now = datetime.now(UTC)
+    now = fixture_clock()
     update_retention_policy(
         session,
         "activity_raw",
@@ -680,8 +683,9 @@ def test_expired_incomplete_heartbeat_does_not_block_current_snapshot(
 def test_empty_authoritative_snapshot_outside_retention_is_rejected(
     client,
     session,
+    fixture_clock,
 ):
-    now = datetime.now(UTC)
+    now = fixture_clock()
     update_retention_policy(
         session,
         "activity_raw",
@@ -754,8 +758,9 @@ def test_future_empty_authoritative_snapshot_is_rejected_without_fence(
 def test_activity_maintenance_expires_android_snapshot_state(
     client,
     session,
+    fixture_clock,
 ):
-    bucket_start = (datetime.now(UTC) - timedelta(hours=2)).replace(
+    bucket_start = (fixture_clock() - timedelta(hours=2)).replace(
         minute=0,
         second=0,
         microsecond=0,

--- a/tests/api/test_intake_interactions.py
+++ b/tests/api/test_intake_interactions.py
@@ -39,6 +39,8 @@ from healthmes.nutrition.vision import VisionUnavailable
 from healthmes.storage import run_storage_maintenance
 from healthmes.store import RetentionPolicy, StorageObject, WellnessEvent
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 JPEG = b"\xff\xd8\xff\xe0synthetic-coffee"
 
 
@@ -1284,7 +1286,11 @@ def test_failed_final_commit_releases_analysis_reservation(client, session):
     assert "nutrition_analysis_reservations" not in session.info
 
 
-def test_expired_sqlite_reservation_rejects_late_owner(client, session):
+def test_expired_sqlite_reservation_rejects_late_owner(
+    client,
+    session,
+    fixture_clock,
+):
     operation_id = uuid.uuid4()
     fingerprint = operation_fingerprint({"fixture": "late-owner"})
 
@@ -1297,9 +1303,9 @@ def test_expired_sqlite_reservation_rejects_late_owner(client, session):
                 reservation = (
                     intake_service_module._STATIC_ANALYSIS_RESERVATIONS[key]
                 )
-                reservation["lease_expires_at"] = datetime.now(
-                    UTC
-                ) - timedelta(seconds=1)
+                reservation["lease_expires_at"] = fixture_clock() - timedelta(
+                    seconds=1
+                )
             with Session(bind=session.get_bind()) as winner_session:
                 create_analyzed_interaction(
                     winner_session,
@@ -1320,7 +1326,7 @@ def test_expired_sqlite_reservation_rejects_late_owner(client, session):
                     source="winner",
                     source_text=text,
                     media_path=None,
-                    recorded_at=datetime.now(UTC),
+                    recorded_at=fixture_clock(),
                     allow_remote_analysis=False,
                     provider=FakeAnalysis(),
                 )
@@ -1343,7 +1349,7 @@ def test_expired_sqlite_reservation_rejects_late_owner(client, session):
             source="late-owner",
             source_text="I ate lunch",
             media_path=None,
-            recorded_at=datetime.now(UTC),
+            recorded_at=fixture_clock(),
             allow_remote_analysis=False,
             provider=ReclaimedDuringAnalysis(),
         )
@@ -2478,11 +2484,12 @@ def test_expired_raw_capture_is_hidden_before_maintenance(client):
 def test_expired_structured_interaction_cannot_be_read_or_promoted(
     client,
     session,
+    fixture_clock,
 ):
     created = client.post(
         "/v1/intake-interactions",
         json=_text_interaction(
-            observed_at=(datetime.now(UTC) - timedelta(minutes=1)).isoformat(),
+            observed_at=(fixture_clock() - timedelta(minutes=1)).isoformat(),
             timezone="UTC",
         ),
     )
@@ -2495,7 +2502,7 @@ def test_expired_structured_interaction_cannot_be_read_or_promoted(
         )
     )
     assert structured is not None
-    structured.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    structured.expires_at = fixture_clock() - timedelta(seconds=1)
     session.commit()
 
     assert (
@@ -2511,7 +2518,7 @@ def test_expired_structured_interaction_cannot_be_read_or_promoted(
             "operation_id": str(uuid.uuid4()),
             "status": "consumed",
             "source": "test",
-            "consumed_at": datetime.now(UTC).isoformat(),
+            "consumed_at": fixture_clock().isoformat(),
         },
     )
     assert outcome.status_code == 422
@@ -2526,7 +2533,11 @@ def test_expired_structured_interaction_cannot_be_read_or_promoted(
     assert decision.status_code == 422
 
 
-def test_expired_snapshots_cannot_restore_an_interaction(client, session):
+def test_expired_snapshots_cannot_restore_an_interaction(
+    client,
+    session,
+    fixture_clock,
+):
     created = client.post(
         "/v1/intake-interactions",
         json=_text_interaction(),
@@ -2567,7 +2578,7 @@ def test_expired_snapshots_cannot_restore_an_interaction(client, session):
         )
     )
     for event in events:
-        event.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        event.expires_at = fixture_clock() - timedelta(seconds=1)
     session.commit()
 
     assert (
@@ -2583,7 +2594,11 @@ def test_expired_snapshots_cannot_restore_an_interaction(client, session):
     )
 
 
-def test_expired_direct_capture_retry_returns_conflict(client, session):
+def test_expired_direct_capture_retry_returns_conflict(
+    client,
+    session,
+    fixture_clock,
+):
     body = _text_interaction()
     created = client.post("/v1/intake-interactions", json=body)
     assert created.status_code == 201
@@ -2595,7 +2610,7 @@ def test_expired_direct_capture_retry_returns_conflict(client, session):
         )
     )
     assert event is not None
-    event.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    event.expires_at = fixture_clock() - timedelta(seconds=1)
     session.commit()
 
     retried = client.post("/v1/intake-interactions", json=body)
@@ -2722,7 +2737,11 @@ def test_provider_warnings_cannot_preserve_raw_owner_text(client, session):
     assert owner_text not in str(event.quality_flags)
 
 
-def test_raw_warnings_never_copy_into_unlimited_snapshots(client, session):
+def test_raw_warnings_never_copy_into_unlimited_snapshots(
+    client,
+    session,
+    fixture_clock,
+):
     owner_text = "private owner text: medication X at 8pm"
 
     class WarningEchoAnalysis(FakeAnalysis):
@@ -2736,7 +2755,7 @@ def test_raw_warnings_never_copy_into_unlimited_snapshots(client, session):
             return extraction
 
     client.app.state.nutrition_analysis_provider = WarningEchoAnalysis()
-    observed_at = datetime.now(UTC).replace(microsecond=0)
+    observed_at = fixture_clock().replace(microsecond=0)
     created = client.post(
         "/v1/intake-interactions/analyze",
         json={

--- a/tests/api/test_nutrition_observations.py
+++ b/tests/api/test_nutrition_observations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
 from sqlalchemy import select
 
 from healthmes.nutrition.contracts import (
@@ -22,6 +23,8 @@ from healthmes.nutrition.schema import (
 from healthmes.nutrition.vision import VisionInvalidOutput, VisionUnavailable
 from healthmes.storage import run_storage_maintenance
 from healthmes.store import RetentionPolicy, StorageObject, WellnessEvent
+
+pytestmark = pytest.mark.usefixtures("fixture_clock")
 
 JPEG = b"\xff\xd8\xff\xe0synthetic-coffee"
 
@@ -560,7 +563,11 @@ def test_photo_raw_evidence_expires_with_media(client, session, settings):
     assert fetched.json()["capture"]["media_path"] == ""
 
 
-def test_expired_observation_cannot_be_read_or_confirmed(client, session):
+def test_expired_observation_cannot_be_read_or_confirmed(
+    client,
+    session,
+    fixture_clock,
+):
     client.app.state.nutrition_vision_provider = FakeVision()
     media_path = _upload(client)
     created = client.post(
@@ -576,7 +583,7 @@ def test_expired_observation_cannot_be_read_or_confirmed(client, session):
         )
     )
     assert event is not None
-    event.expires_at = datetime.now(UTC)
+    event.expires_at = fixture_clock()
     session.commit()
 
     assert (

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -25,6 +25,8 @@ from healthmes.store import (
     WellnessEvent,
 )
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def test_storage_settings_bootstraps_defaults_and_measures_files(
     client: TestClient, settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,30 @@ fixture points at in-memory sqlite and dummy endpoints, and disables both
 ``.env`` loading and the scheduler.
 """
 
+from datetime import UTC, datetime, timedelta
+from time import monotonic
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from healthmes import clock
 from healthmes.app import create_app
 from healthmes.config import Settings
+
+FIXTURE_NOW = datetime(2026, 8, 10, 12, tzinfo=UTC)
+
+
+@pytest.fixture
+def fixture_clock(monkeypatch):
+    """Run fixed-date fixtures against their intended retention timeline."""
+    started_at = monotonic()
+
+    def now() -> datetime:
+        return FIXTURE_NOW + timedelta(seconds=monotonic() - started_at)
+
+    monkeypatch.setattr(clock, "utc_now", now)
+    return now
 
 
 @pytest.fixture

--- a/tests/mcp_server/test_tools_intake.py
+++ b/tests/mcp_server/test_tools_intake.py
@@ -20,6 +20,8 @@ from healthmes.nutrition.transcription import TranscriptionResult
 from healthmes.storage import register_storage_object
 from healthmes.trusted_session import issue_trusted_session_proof
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def _trusted(tool_name, arguments):
     proof = issue_trusted_session_proof(

--- a/tests/mcp_server/test_tools_nutrition.py
+++ b/tests/mcp_server/test_tools_nutrition.py
@@ -30,6 +30,8 @@ from healthmes.storage import register_storage_object
 from healthmes.store import WellnessEvent
 from healthmes.trusted_session import issue_trusted_session_proof
 
+pytestmark = pytest.mark.usefixtures("fixture_clock")
+
 
 def _observation(observed_at: dt.datetime, media_path: str) -> NutritionObservation:
     return NutritionObservation(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -24,16 +24,16 @@ wheels = [
 
 [[package]]
 name = "alembic"
-version = "1.18.5"
+version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/cc/ac0bed8e562e7407fe55c3ba85a4dce86e6dbd8730887bd1e406a6c5c18a/alembic-1.18.5.tar.gz", hash = "sha256:1554982221dd17e9a749b53902407578eb305e453f71999e8c7f0a48389fff8e", size = 2060480, upload-time = "2026-06-25T15:20:54.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/2b/e4153978368de59918115c9e01d3ebf58a558a7285efa7e960c383c4b59a/alembic-1.19.1.tar.gz", hash = "sha256:e0fca0518118c78acc493e31bcb5402f190057aaf6df8b5b95ce94c4789cf648", size = 2070816, upload-time = "2026-08-08T16:32:01.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/78/5fe6dc3a3a5b2f5a2a4faef8bfe336d5fa049a38884ab3172e0098160c01/alembic-1.18.5-py3-none-any.whl", hash = "sha256:06d8ba9d04558022f5395e9317de03d270f3dced49cee01f89fe7a13c26f14bc", size = 264664, upload-time = "2026-06-25T15:20:56.673Z" },
+    { url = "https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl", hash = "sha256:b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be", size = 265946, upload-time = "2026-08-08T16:32:03.153Z" },
 ]
 
 [[package]]
@@ -112,30 +112,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.58"
+version = "1.43.67"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/95/bd6276870084c9c1a94e17d1dc73b2de275e59bd7a0ad8bfff0a1598cec4/boto3-1.43.58.tar.gz", hash = "sha256:12871fb50c383f1b9aa4ed6dd386ba689062baef730552e79d5a9cd782b53058", size = 112685, upload-time = "2026-07-28T19:35:09.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/bf/ef5de9b55523bc2141d072fbe6614627088e3e6f97b47850216e99de6a1c/boto3-1.43.67.tar.gz", hash = "sha256:75fe983b70d39cfdc274dc51f9bb02b8a0a104bdad4fa073c1af85a35e707c91", size = 112665, upload-time = "2026-08-07T19:30:20.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/85/b0709066efb4ce7b86aba4092c739ad0e458be9d62cf32550fc4c130c93f/boto3-1.43.58-py3-none-any.whl", hash = "sha256:ce1a20cbcfaa1d0b3c8f568e2b6c7fbd34b842ea00e729d49a4b4de522828db9", size = 140026, upload-time = "2026-07-28T19:35:06.993Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0f/b41f8968452dc6bf3b83f15f5e9f76a27fd93e246906aeb2e0555f494375/boto3-1.43.67-py3-none-any.whl", hash = "sha256:082cf9df068168cb44028a1703822374c1eb7e48fa49470d7e8a76f0c977d0bc", size = 140025, upload-time = "2026-08-07T19:30:18.49Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.58"
+version = "1.43.69"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/64/5cd46a7e72b0647e6d78fc8da016259ad66b9ae0818f4c5d629c75e7ca49/botocore-1.43.58.tar.gz", hash = "sha256:e110ca53f65c128fe98df4d6d36a459b1db17c6114671c8a18becf151bf20909", size = 15742412, upload-time = "2026-07-28T19:34:57.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/da/726b23443ebc77078387fbf330ef7240bc6a96553e566e45a647cd8f714c/botocore-1.43.69.tar.gz", hash = "sha256:5caa46b740d9a886137146ffbb69edb691f702bfe74c64e85621947ae00181fd", size = 15911844, upload-time = "2026-08-11T19:24:20.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/82/6f8fbbea47b773734ba0199643d2d851e5c2f75bc3699fe99db8af344d96/botocore-1.43.58-py3-none-any.whl", hash = "sha256:f516159f0732da8249206163ccea3bd1f82ad2a9d184fe6ed447e1abdba4330e", size = 15426503, upload-time = "2026-07-28T19:34:53.508Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ef/a1effbe4ffabadc38ea9425c54601262eaac8cbb5b6089f8f76536d3c8b1/botocore-1.43.69-py3-none-any.whl", hash = "sha256:b1f0e01c53d6b84ee9c184ebf3636c3b3aef85e0ae8498c74afb8734ff224f87", size = 15596589, upload-time = "2026-08-11T19:24:18.283Z" },
 ]
 
 [[package]]
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.140.13"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -494,26 +494,26 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/cb/7a4d2c2eb5a5d8a91763c05b7383d72917862e32f780daa0e27ffbb34cc6/fastapi-0.140.13.tar.gz", hash = "sha256:500172a08cf1459901f90b05c37d93060dada3b573fec8f0862445db52ba6b4b", size = 424843, upload-time = "2026-07-28T15:37:00.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/4e/f9e8c762ef5e05c40482131e3d5e8b36bca13fa127578261f1d6b35a25d4/fastapi-0.140.13-py3-none-any.whl", hash = "sha256:8b017110e1e9f30a95e8bdb8f71fbe2f0fe3af5717109e5b14f9e069df54f6d4", size = 131222, upload-time = "2026-07-28T15:37:02.124Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
 name = "fastmcp"
-version = "3.4.5"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/14/c1ffb91b7d1fece86c81e1f9df5474f30fd97e4cdaa398814bbbeee88568/fastmcp-3.4.5.tar.gz", hash = "sha256:a95f2bc876bef42e8b50f7872f24f3f2fe3b1d37408c734e8b9d9e03014b72d3", size = 28800521, upload-time = "2026-07-27T19:20:01.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/e2c78e26233cd8a416b21513e1925435d54c008a0ec467dbdaa80369daf7/fastmcp-3.4.6.tar.gz", hash = "sha256:2287938da8364ad7071bec2d2393af6ae10fd4e836f06f506569f1456cc87eb4", size = 28808130, upload-time = "2026-08-05T14:54:42.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a5/c02275db111892388972edbb05fbcbfdf1e83cbd1fd03356b3a49b93f839/fastmcp-3.4.6-py3-none-any.whl", hash = "sha256:2a29967be9f68cdd1b4cefb413ede74f83adefd923919a37aaac3611eccdd749", size = 8017, upload-time = "2026-08-05T14:54:38.473Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.5"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -523,9 +523,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1d/f3e271fbcd01ce01a4cf623b336d8e1305c192aa5d5e8e0223b7167462e9/fastmcp_slim-3.4.5.tar.gz", hash = "sha256:5badc3bceee61f61297eeb9494f499325f3ce1cafabf4611b31f6c3e9d7dff59", size = 591622, upload-time = "2026-07-27T19:15:19.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b6/b5b9e81e67a3f39534881d2af6aa3fbd2dc367eaa070c3c932770a0c062f/fastmcp_slim-3.4.6.tar.gz", hash = "sha256:6a1e6e42c697ba90abcb1be617a26947d07316f13c6fa138ae7b0de24558e32c", size = 594167, upload-time = "2026-08-05T14:54:15.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/3b/16d8aa8224094519f30b078138e725b8a731bf0a13f1f850e58b5f9b3cc4/fastmcp_slim-3.4.5-py3-none-any.whl", hash = "sha256:bc31217827c4999812543c83ee95ed9a47f3ed1e3fd0bd4f64371e375b748eca", size = 766478, upload-time = "2026-07-27T19:15:18.015Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/02c254c46b4323ae5262b76a29af73b50a863efc5739a3454d144d3605ee/fastmcp_slim-3.4.6-py3-none-any.whl", hash = "sha256:3e08e6acb03523a47aa17f4d2ab9943e648a41e20b24084da491a732c46dffdc", size = 769174, upload-time = "2026-08-05T14:54:14.663Z" },
 ]
 
 [package.optional-dependencies]
@@ -666,9 +666,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
     { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
     { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
     { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
     { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
     { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
     { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
@@ -676,9 +674,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
-    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -686,9 +682,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
     { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
     { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
     { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
-    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
     { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
     { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
     { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
@@ -696,18 +690,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
     { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
     { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
     { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
     { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
     { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
     { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
     { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
     { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
     { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
-    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
     { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
     { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
     { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
     { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
@@ -715,9 +705,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
     { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
     { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
     { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
     { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
     { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
     { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
@@ -785,7 +773,7 @@ dev = [
 requires-dist = [
     { name = "alembic" },
     { name = "apscheduler", specifier = ">=3.10,<4" },
-    { name = "boto3", specifier = ">=1.43.58" },
+    { name = "boto3", specifier = ">=1.43.67" },
     { name = "caldav" },
     { name = "croniter" },
     { name = "fastapi" },
@@ -1821,16 +1809,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.2"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
 ]
 
 [[package]]
@@ -2273,27 +2261,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.0"
+version = "0.16.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
-    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
-    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
 ]
 
 [[package]]
@@ -2313,8 +2301,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- run fixed-date retention fixtures on an explicit 2026-08-10 UTC clock seam instead of wall-clock time
- consolidate compatible Dependabot updates from #141, #140, #104, #103, #102, and #18
- align Android with AGP 9 built-in Kotlin, Compose compiler 2.4.10, Compose BOM 2026.06.01, ProtoLayout 1.4.2, org.json 20260719, and explicit material icons
- update AndroidX core from 1.13.1 to the latest API-36-compatible line, 1.18.0

## Validation
- `uv run ruff check .`
- `uv run pytest -q`: 1994 passed, 25 skipped
- retention regression set: 302 passed
- Android full matrix: `BUILD SUCCESSFUL` (`:app` assemble/tests, `:companion` assemble/tests, `:wear` assemble)
- Alembic offline SQLite render: 639 lines

## Dependabot resolution
- Supersedes #141, #140, #104, #103, #102, and #18 with their changes plus required compatibility fixes.
- #15 requests core-ktx 1.19.0, whose AAR metadata requires compileSdk 37. As of August 18, 2026, `sdkmanager` does not publish `platforms;android-37`; this PR uses core-ktx 1.18.0, the highest buildable API-36-compatible version, and #15 will be closed with that constraint documented.
