### PR TITLE
vendor(ow): ingest and refresh WHOOP cycle day strain

### DIFF
--- a/vendor/open-wearables/backend/app/constants/health_scores.py
+++ b/vendor/open-wearables/backend/app/constants/health_scores.py
@@ -38,4 +38,7 @@ HEALTH_SCORE_RANGES: dict[HealthScoreCategory, dict[ProviderName, ScoreRange]] =
         ProviderName.WHOOP: ScoreRange(0, 21),
         ProviderName.POLAR: ScoreRange(0, float("inf")),
     },
+    HealthScoreCategory.DAY_STRAIN: {
+        ProviderName.WHOOP: ScoreRange(0, 21),
+    },
 }

--- a/vendor/open-wearables/backend/app/repositories/health_score_repository.py
+++ b/vendor/open-wearables/backend/app/repositories/health_score_repository.py
@@ -2,13 +2,14 @@ from datetime import date, datetime, timezone
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import and_, asc, desc, tuple_
+from sqlalchemy import DateTime, and_, asc, desc, tuple_
+from sqlalchemy import cast as sql_cast
 from sqlalchemy.dialects.postgresql import insert
 
 from app.database import DbSession
 from app.models import HealthScore
 from app.repositories.repositories import CrudRepository
-from app.schemas.enums import HealthScoreCategory
+from app.schemas.enums import HealthScoreCategory, ProviderName
 from app.schemas.model_crud.activities import HealthScoreCreate, HealthScoreQueryParams, HealthScoreUpdate
 from app.utils.pagination import decode_cursor
 
@@ -57,6 +58,47 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
         stmt = insert(HealthScore).values(values).on_conflict_do_nothing()
         db_session.execute(stmt)
         # Caller is responsible for commit — allows batching with other operations
+
+    def upsert_whoop_day_strain(
+        self,
+        db_session: DbSession,
+        creators: list[HealthScoreCreate],
+    ) -> None:
+        """Insert WHOOP Cycle strain and refresh only newer revisions of the same cycle.
+
+        This is intentionally separate from ``bulk_create``: other provider
+        health scores retain their existing insert-only semantics.
+        """
+        if not creators:
+            return
+
+        for creator in creators:
+            values = creator.model_dump()
+            stmt = insert(HealthScore).values(values)
+            existing_cycle_id = HealthScore.components["cycle_id"]["qualifier"].astext
+            incoming_cycle_id = stmt.excluded.components["cycle_id"]["qualifier"].astext
+            existing_updated_at = sql_cast(
+                HealthScore.components["cycle_updated_at"]["qualifier"].astext,
+                DateTime(timezone=True),
+            )
+            incoming_updated_at = sql_cast(
+                stmt.excluded.components["cycle_updated_at"]["qualifier"].astext,
+                DateTime(timezone=True),
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["user_id", "provider", "category", "recorded_at"],
+                set_={
+                    "value": stmt.excluded.value,
+                    "components": stmt.excluded.components,
+                },
+                where=and_(
+                    HealthScore.provider == ProviderName.WHOOP,
+                    HealthScore.category == HealthScoreCategory.DAY_STRAIN,
+                    existing_cycle_id == incoming_cycle_id,
+                    existing_updated_at < incoming_updated_at,
+                ),
+            )
+            db_session.execute(stmt)
 
     def get_latest_by_category(
         self,

--- a/vendor/open-wearables/backend/app/schemas/enums/health_score_category.py
+++ b/vendor/open-wearables/backend/app/schemas/enums/health_score_category.py
@@ -10,3 +10,4 @@ class HealthScoreCategory(StrEnum):
     RESILIENCE = "resilience"
     BODY_BATTERY = "body_battery"
     STRAIN = "strain"
+    DAY_STRAIN = "day_strain"

--- a/vendor/open-wearables/backend/app/services/health_score_service.py
+++ b/vendor/open-wearables/backend/app/services/health_score_service.py
@@ -31,6 +31,10 @@ class HealthScoreService(
         self.crud.bulk_create(db_session, scores)
 
     @handle_exceptions
+    def upsert_whoop_day_strain(self, db_session: DbSession, scores: list[HealthScoreCreate]) -> None:
+        self.crud.upsert_whoop_day_strain(db_session, scores)
+
+    @handle_exceptions
     def get_latest_by_category(
         self,
         db_session: DbSession,

--- a/vendor/open-wearables/backend/app/services/providers/whoop/coverage.py
+++ b/vendor/open-wearables/backend/app/services/providers/whoop/coverage.py
@@ -48,5 +48,6 @@ HEALTH_SCORES: frozenset[HealthScoreCategory] = frozenset(
         HealthScoreCategory.SLEEP,
         HealthScoreCategory.RECOVERY,
         HealthScoreCategory.STRAIN,
+        HealthScoreCategory.DAY_STRAIN,
     }
 )

--- a/vendor/open-wearables/backend/app/services/providers/whoop/data_247.py
+++ b/vendor/open-wearables/backend/app/services/providers/whoop/data_247.py
@@ -461,6 +461,7 @@ class Whoop247Data(Base247DataTemplate):
         results = {
             "sleep_sessions_synced": 0,
             "recovery_samples_synced": 0,
+            "day_strain_scores_synced": 0,
             "activity_samples_synced": 0,
             "body_measurement_samples_synced": 0,
         }
@@ -486,6 +487,19 @@ class Whoop247Data(Base247DataTemplate):
                 self.logger,
                 "error",
                 f"Failed to sync recovery data: {e}",
+                provider="whoop",
+                task="load_and_save_all",
+                user_id=str(user_id),
+            )
+
+        try:
+            results["day_strain_scores_synced"] = self.load_and_save_day_strain(db, user_id, start_time, end_time)
+        except Exception as e:
+            db.rollback()
+            log_structured(
+                self.logger,
+                "error",
+                f"Failed to sync Whoop day strain: {e}",
                 provider="whoop",
                 task="load_and_save_all",
                 user_id=str(user_id),
@@ -736,6 +750,9 @@ class Whoop247Data(Base247DataTemplate):
             for k in ("resting_heart_rate", "hrv_rmssd_milli", "spo2_percentage", "skin_temp_celsius")
             if normalized.get(k) is not None
         }
+        cycle_id = normalized.get("cycle_id")
+        if cycle_id is not None:
+            components["cycle_id"] = ScoreComponent(qualifier=str(cycle_id))
         return HealthScoreCreate(
             id=uuid4(),
             user_id=user_id,
@@ -934,6 +951,93 @@ class Whoop247Data(Base247DataTemplate):
             db.commit()
 
         return total_count
+
+    def get_cycle_data(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch cumulative WHOOP Cycle scores from the v2 cycle endpoint."""
+        all_cycle_data: list[dict[str, Any]] = []
+        next_token = None
+        start_iso = start_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        end_iso = end_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        while True:
+            params: dict[str, Any] = {"start": start_iso, "end": end_iso, "limit": 25}
+            if next_token:
+                params["nextToken"] = next_token
+
+            response = self._make_api_request(db, user_id, "/v2/cycle", params=params)
+            store_raw_payload(
+                source="api_response",
+                provider="whoop",
+                payload=response,
+                user_id=str(user_id),
+                trace_id="/v2/cycle",
+            )
+            records = response.get("records", []) if isinstance(response, dict) else []
+            all_cycle_data.extend(record for record in records if isinstance(record, dict))
+            next_token = response.get("next_token") if isinstance(response, dict) else None
+            if not records or not next_token:
+                return all_cycle_data
+
+    def normalize_day_strain_health_score(
+        self,
+        raw_cycle: dict[str, Any],
+        user_id: UUID,
+    ) -> HealthScoreCreate | None:
+        """Normalize one scored WHOOP Cycle cumulative strain value."""
+        if raw_cycle.get("score_state") != "SCORED":
+            return None
+
+        score = raw_cycle.get("score") or {}
+        value = score.get("strain") if isinstance(score, dict) else None
+        cycle_start = raw_cycle.get("start")
+        updated_at = raw_cycle.get("updated_at")
+        cycle_id = raw_cycle.get("id")
+        if value is None or cycle_start is None or updated_at is None or cycle_id is None:
+            return None
+        try:
+            recorded_at = datetime.fromisoformat(str(cycle_start).replace("Z", "+00:00"))
+            source_updated_at = datetime.fromisoformat(str(updated_at).replace("Z", "+00:00"))
+            value = float(value)
+        except (TypeError, ValueError):
+            return None
+
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=user_id,
+            provider=ProviderName.WHOOP,
+            category=HealthScoreCategory.DAY_STRAIN,
+            value=value,
+            recorded_at=recorded_at,
+            components={
+                "cycle_id": ScoreComponent(qualifier=str(cycle_id)),
+                "cycle_updated_at": ScoreComponent(qualifier=source_updated_at.isoformat()),
+            },
+        )
+
+    def load_and_save_day_strain(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> int:
+        """Persist scored WHOOP Cycle strain, refreshing newer revisions."""
+        health_scores = [
+            score
+            for raw_cycle in self.get_cycle_data(db, user_id, start_time, end_time)
+            if (score := self.normalize_day_strain_health_score(raw_cycle, user_id)) is not None
+        ]
+        if not health_scores:
+            return 0
+        health_score_service.upsert_whoop_day_strain(db, health_scores)
+        db.commit()
+        return len(health_scores)
 
     # -------------------------------------------------------------------------
     # Activity Samples

--- a/vendor/open-wearables/backend/tests/providers/whoop/test_whoop_day_strain.py
+++ b/vendor/open-wearables/backend/tests/providers/whoop/test_whoop_day_strain.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.constants.health_scores import HEALTH_SCORE_RANGES, ScoreRange
+from app.schemas.enums import HealthScoreCategory, ProviderName
+from app.services.providers.whoop.data_247 import Whoop247Data
+from app.services.providers.whoop.strategy import WhoopStrategy
+
+
+@pytest.fixture
+def data_247() -> Whoop247Data:
+    return WhoopStrategy().data_247
+
+
+@pytest.fixture
+def scored_cycle() -> dict:
+    return {
+        "id": 93845,
+        "start": "2026-08-13T01:30:00Z",
+        "updated_at": "2026-08-13T06:20:00Z",
+        "score_state": "SCORED",
+        "score": {"strain": 14.2},
+    }
+
+
+class TestWhoopDayStrain:
+    def test_declares_the_same_whoop_scale_as_strain(self) -> None:
+        assert HEALTH_SCORE_RANGES[HealthScoreCategory.DAY_STRAIN][ProviderName.WHOOP] == ScoreRange(0, 21)
+
+    def test_normalizes_cycle_strain_separately_from_workout_strain(
+        self, data_247: Whoop247Data, scored_cycle: dict
+    ) -> None:
+        user_id = uuid4()
+
+        score = data_247.normalize_day_strain_health_score(scored_cycle, user_id)
+
+        assert score is not None
+        assert score.category == HealthScoreCategory.DAY_STRAIN
+        assert score.value == 14.2
+        assert score.recorded_at == datetime(2026, 8, 13, 1, 30, tzinfo=timezone.utc)
+        assert score.components is not None
+        assert score.components["cycle_id"].qualifier == "93845"
+        assert score.components["cycle_updated_at"].qualifier == "2026-08-13T06:20:00+00:00"
+
+    def test_keeps_recovery_cycle_identity(self, data_247: Whoop247Data) -> None:
+        user_id = uuid4()
+        normalized = {
+            "timestamp": datetime(2026, 8, 13, 6, 20, tzinfo=timezone.utc),
+            "cycle_id": 93845,
+            "recovery_score": 72,
+            "resting_heart_rate": 55,
+        }
+
+        score = data_247._normalize_recovery_health_score(normalized, user_id)
+
+        assert score is not None
+        assert score.components is not None
+        assert score.components["cycle_id"].qualifier == "93845"
+
+    def test_rejects_unscored_or_unparseable_cycles(self, data_247: Whoop247Data, scored_cycle: dict) -> None:
+        user_id = uuid4()
+        scored_cycle["score_state"] = "PENDING_SCORE"
+        assert data_247.normalize_day_strain_health_score(scored_cycle, user_id) is None
+
+        scored_cycle["score_state"] = "SCORED"
+        scored_cycle["updated_at"] = "not-a-timestamp"
+        assert data_247.normalize_day_strain_health_score(scored_cycle, user_id) is None
+
+    @patch("app.services.providers.whoop.data_247.health_score_service")
+    def test_persists_cycle_scores_with_their_cycle_start_time(
+        self, health_score_service: MagicMock, data_247: Whoop247Data, scored_cycle: dict
+    ) -> None:
+        db = MagicMock()
+        with patch.object(data_247, "get_cycle_data", return_value=[scored_cycle]):
+            count = data_247.load_and_save_day_strain(
+                db,
+                uuid4(),
+                datetime(2026, 8, 12, tzinfo=timezone.utc),
+                datetime(2026, 8, 13, tzinfo=timezone.utc),
+            )
+
+        assert count == 1
+        health_score_service.upsert_whoop_day_strain.assert_called_once()
+        persisted = health_score_service.upsert_whoop_day_strain.call_args.args[1][0]
+        assert persisted.category == HealthScoreCategory.DAY_STRAIN
+        assert persisted.recorded_at == datetime(2026, 8, 13, 1, 30, tzinfo=timezone.utc)
+        assert persisted.components is not None
+        assert persisted.components["cycle_updated_at"].qualifier == "2026-08-13T06:20:00+00:00"
+        db.commit.assert_called_once()

--- a/vendor/open-wearables/backend/tests/repositories/test_health_score_repository.py
+++ b/vendor/open-wearables/backend/tests/repositories/test_health_score_repository.py
@@ -16,10 +16,10 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from app.models import HealthScore
+from app.models import DataSource, HealthScore
 from app.repositories.health_score_repository import HealthScoreRepository
 from app.schemas.enums import HealthScoreCategory, ProviderName
-from app.schemas.model_crud.activities import HealthScoreCreate, HealthScoreQueryParams
+from app.schemas.model_crud.activities import HealthScoreCreate, HealthScoreQueryParams, ScoreComponent
 from tests.factories import DataSourceFactory, HealthScoreFactory, UserFactory
 
 
@@ -230,3 +230,100 @@ class TestHealthScoreRepositoryBulkCreate:
         results = db.query(HealthScore).filter(HealthScore.data_source_id == data_source.id).all()
         assert len(results) == 1
         assert results[0].value == Decimal("80.00")
+
+
+class TestHealthScoreRepositoryWhoopDayStrain:
+    @staticmethod
+    def _score(
+        data_source: DataSource,
+        *,
+        value: str,
+        cycle_updated_at: str,
+        cycle_id: str = "cycle-1",
+    ) -> HealthScoreCreate:
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=data_source.user_id,
+            data_source_id=data_source.id,
+            provider=ProviderName.WHOOP,
+            category=HealthScoreCategory.DAY_STRAIN,
+            value=Decimal(value),
+            recorded_at=datetime(2026, 8, 13, 1, 30, tzinfo=timezone.utc),
+            components={
+                "cycle_id": ScoreComponent(qualifier=cycle_id),
+                "cycle_updated_at": ScoreComponent(qualifier=cycle_updated_at),
+            },
+        )
+
+    def test_newer_revision_updates_same_cycle_and_older_revision_is_ignored(
+        self, db: Session, repo: HealthScoreRepository
+    ) -> None:
+        data_source = DataSourceFactory()
+        original = self._score(
+            data_source,
+            value="10.5",
+            cycle_updated_at="2026-08-13T06:20:00+00:00",
+        )
+        repo.upsert_whoop_day_strain(db, [original])
+        db.commit()
+
+        newer = self._score(
+            data_source,
+            value="14.2",
+            cycle_updated_at="2026-08-13T08:20:00+00:00",
+        )
+        repo.upsert_whoop_day_strain(db, [newer])
+        db.commit()
+
+        row = (
+            db.query(HealthScore)
+            .filter(
+                HealthScore.user_id == data_source.user_id,
+                HealthScore.category == HealthScoreCategory.DAY_STRAIN,
+            )
+            .one()
+        )
+        assert row.value == Decimal("14.2")
+        assert row.components["cycle_updated_at"]["qualifier"] == "2026-08-13T08:20:00+00:00"
+
+        older = self._score(
+            data_source,
+            value="11.1",
+            cycle_updated_at="2026-08-13T07:20:00+00:00",
+        )
+        repo.upsert_whoop_day_strain(db, [older])
+        db.commit()
+
+        db.refresh(row)
+        assert row.value == Decimal("14.2")
+        assert row.components["cycle_updated_at"]["qualifier"] == "2026-08-13T08:20:00+00:00"
+
+    def test_different_cycle_does_not_replace_existing_row(self, db: Session, repo: HealthScoreRepository) -> None:
+        data_source = DataSourceFactory()
+        original = self._score(
+            data_source,
+            value="10.5",
+            cycle_updated_at="2026-08-13T06:20:00+00:00",
+        )
+        repo.upsert_whoop_day_strain(db, [original])
+        db.commit()
+
+        different_cycle = self._score(
+            data_source,
+            value="14.2",
+            cycle_updated_at="2026-08-13T08:20:00+00:00",
+            cycle_id="cycle-2",
+        )
+        repo.upsert_whoop_day_strain(db, [different_cycle])
+        db.commit()
+
+        row = (
+            db.query(HealthScore)
+            .filter(
+                HealthScore.user_id == data_source.user_id,
+                HealthScore.category == HealthScoreCategory.DAY_STRAIN,
+            )
+            .one()
+        )
+        assert row.value == Decimal("10.5")
+        assert row.components["cycle_id"]["qualifier"] == "cycle-1"


### PR DESCRIPTION
## Summary

Adds the missing Open Wearables normalization for WHOOP Cycle cumulative day strain, separately from HealthMes interpretation logic.

- Preserve the WHOOP recovery `cycle_id` in the stored Recovery health-score components.
- Ingest scored `/v2/cycle` day strain with its cycle start and source revision timestamp.
- Refresh an existing WHOOP day-strain row only for the same cycle and a strictly newer `cycle_updated_at`; all generic health-score inserts remain insert-only.

## Why This Is Separate

HealthMes cannot safely repair provider normalization or re-sync persistence above the vendor boundary. Keeping this patch isolated makes the Open Wearables delta reviewable and lets #157 retain its existing feature commits unchanged.

## Vendor Base And Reapply

- Base: the Open Wearables snapshot vendored by HealthMes `main` at `c0e3f780`.
- Reapply plan: retain this focused commit while the vendor snapshot is current; when the vendor snapshot is upgraded, reapply or replace it against the upstream implementation after verifying the same cycle-ID and newer-revision contract.

## Validation

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `18 passed`: WHOOP day-strain normalization plus PostgreSQL repository regressions for newer and older re-sync revisions.

Related to #157. Required by #157; this PR intentionally does not close it.